### PR TITLE
Remove jest-specific lint config

### DIFF
--- a/packages/fractal-page-object/.eslintrc.js
+++ b/packages/fractal-page-object/.eslintrc.js
@@ -25,13 +25,6 @@ module.exports = {
         'no-unused-vars': 'off',
       },
     },
-    // tests
-    {
-      files: ['**/__tests__/**/*./ts'],
-      env: {
-        jest: true,
-      },
-    },
     // node files
     {
       files: ['.eslintrc.js'],

--- a/packages/fractal-page-object/src/__tests__/dom-query.ts
+++ b/packages/fractal-page-object/src/__tests__/dom-query.ts
@@ -1,4 +1,4 @@
-import { describe, test } from '@jest/globals';
+import { describe, test, expect } from '@jest/globals';
 import DOMQuery from '../-private/dom-query';
 
 describe('DOMQuery', () => {

--- a/packages/fractal-page-object/src/__tests__/global-selector.ts
+++ b/packages/fractal-page-object/src/__tests__/global-selector.ts
@@ -1,4 +1,4 @@
-import { describe, test } from '@jest/globals';
+import { describe, afterEach, test, expect } from '@jest/globals';
 import { selector, globalSelector, PageObject, setRoot } from '..';
 import { resetRoot } from '../-private/root';
 

--- a/packages/fractal-page-object/src/__tests__/page-object.ts
+++ b/packages/fractal-page-object/src/__tests__/page-object.ts
@@ -1,4 +1,4 @@
-import { describe, afterEach, test } from '@jest/globals';
+import { describe, afterEach, test, expect } from '@jest/globals';
 import { PageObject, setRoot } from '..';
 import { resetRoot } from '../-private/root';
 import { DOM_QUERY, CLONE_WITH_INDEX } from '../-private/types';

--- a/packages/fractal-page-object/src/__tests__/selector.ts
+++ b/packages/fractal-page-object/src/__tests__/selector.ts
@@ -1,4 +1,4 @@
-import { describe, test } from '@jest/globals';
+import { describe, test, expect } from '@jest/globals';
 import { selector, PageObject } from '..';
 
 describe('selector()', () => {


### PR DESCRIPTION
Import all our jest globals explicitly, and remove the jest-specific eslint config since we aren't using any magic globals anymore