### PR TITLE
Make DOM queries fully lazy

### DIFF
--- a/packages/fractal-page-object/package.json
+++ b/packages/fractal-page-object/package.json
@@ -25,7 +25,8 @@
     "prepublish": "yarn build",
     "release": "dotenv release-it",
     "test": "jest",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:debug": "node --inspect-brk ./node_modules/.bin/jest --runInBand"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/fractal-page-object/src/-private/dom-query.ts
+++ b/packages/fractal-page-object/src/-private/dom-query.ts
@@ -1,30 +1,107 @@
 /**
+ * An element of a {@link SelectorArray}, comprising a selector and optional
+ * index. This is to support a DOM query/selector language that allows indexing.
+ */
+interface SelectorFragment {
+  selector: string;
+  index?: number;
+}
+
+/**
+ * A class that represents a flexible selector, allowing intermediate indices.
+ * It's an array of {@link SelectorFragment}s that represents a set of query and
+ * index instructions allowing DOM queries that include indexing.
+ */
+class SelectorArray extends Array<SelectorFragment> {
+  /**
+   * Create a new selector array that extends this one with either another
+   * selector, or an indexing operation.
+   *
+   * @param val the selector or index with which to extend this selector array
+   */
+  extend(val: string | number) {
+    let extended = new SelectorArray(...this);
+
+    let prevFragment = extended[extended.length - 1];
+
+    if (typeof val === 'string') {
+      if (prevFragment && prevFragment.index === undefined) {
+        // We have a previous fragment without an index, so we can combine this
+        // selector with the previous fragment's
+        prevFragment.selector = `${prevFragment.selector} ${val}`;
+      } else {
+        // No previous fragment, or previous fragment already has an index, so
+        // we have to add a new fragment
+        extended.push({ selector: val });
+      }
+    } else {
+      if (prevFragment && prevFragment.index === undefined) {
+        // We have a previous fragment without an index, so we can add this
+        // index to it
+        prevFragment.index = val;
+      } else {
+        // No previous fragment, or previous fragment already has an index, so
+        // we need to add a new fragment with an empty selector and this index
+        extended.push({ selector: '', index: val });
+      }
+    }
+    return extended;
+  }
+
+  /**
+   * A string representation of this selector array, e.g. `div span[1] strong`
+   */
+  toString() {
+    let str = '';
+    for (let { selector, index } of this) {
+      str = `${str} ${selector}`.trim();
+      if (index !== undefined) {
+        str = `${str}[${index}]`;
+      }
+    }
+    return str;
+  }
+}
+
+/**
  * A class that can execute selector-based DOM queries, with supporting for
  * intermediate indexing.
  */
 export default class DOMQuery {
   /**
    * @param root the root element from which to query
-   * @param selector the selector to query
+   * @param selectorArray the selector array describing the query to execute
    */
   constructor(
     public readonly root: Element | null,
-    public readonly selector: string
+    public readonly selectorArray: SelectorArray = new SelectorArray()
   ) {}
 
   /**
    * Query the first matching element
    */
   query(): Element | null {
-    if (!this.root) {
-      return null;
-    }
+    let el = this.root;
+    for (let { selector, index } of this.selectorArray) {
+      if (!el) {
+        break;
+      }
 
-    if (this.selector) {
-      return this.root.querySelector(this.selector);
-    } else {
-      return this.root;
+      if (index !== undefined) {
+        if (selector) {
+          // Selector and index, so query all and index into result set
+          el = el.querySelectorAll(selector)[index];
+        } else {
+          // Only index, so index into the result set, which is just the current
+          // element
+          el = [el][index];
+        }
+      } else {
+        // Only a selector
+        el = el.querySelector(selector);
+      }
     }
+    return el || null;
   }
 
   /**
@@ -35,35 +112,47 @@ export default class DOMQuery {
       return [];
     }
 
-    if (this.selector) {
-      return Array.from(this.root.querySelectorAll(this.selector));
-    } else {
-      return [this.root];
+    let matches = [this.root];
+    for (let { selector, index } of this.selectorArray) {
+      if (matches.length === 0) {
+        break;
+      }
+
+      if (index !== undefined) {
+        let el;
+        if (selector) {
+          // Selector and index, so query all and index into the result set
+          el = matches[0].querySelectorAll(selector)[index];
+        } else {
+          // Only index, so index into the result set, which is just the current
+          // element
+          el = matches[index!];
+        }
+        // Convert to singleton array
+        matches = el ? [el] : [];
+      } else {
+        // Only a selector, so query for result set and covert to array
+        matches = Array.from(matches[0].querySelectorAll(selector));
+      }
     }
+    return matches;
   }
 
   /**
    * Create a child {@link DOMQuery} from a selector and an optional index.
-   * {@link DOMQuery} objects created using this method are not guaranteed to be
-   * lazy -- if an index is specified, the query will be executed immediately.
    *
    * @param selector selector to query
    * @param index target index of the {@link Element} in the query results, or
    * null if this isn't an index query
    */
   createChild(selector: string, index: number | null) {
-    // Create a DOMQuery just using the selector, and ignoring the index, which
-    // is accomplished by appending the new selector to ours and keeping the
-    // same root.
-    let child = new DOMQuery(this.root, `${this.selector} ${selector}`.trim());
-    if (index !== null) {
-      // We have an index, so we have to query all matching elements to find the
-      // one we are targeting, and set that as our root with no selector.
-      let element = child.queryAll()[index] || null;
-      return new DOMQuery(element, '');
-    } else {
-      // No index, so nothing extra to do
-      return child;
+    let child = this.selectorArray;
+    if (selector) {
+      child = child.extend(selector);
     }
+    if (index !== null) {
+      child = child.extend(index);
+    }
+    return new DOMQuery(this.root, child);
   }
 }

--- a/packages/fractal-page-object/src/__tests__/page-object.ts
+++ b/packages/fractal-page-object/src/__tests__/page-object.ts
@@ -15,40 +15,33 @@ describe('PageObject', () => {
 
       function checkQuery(
         page: PageObject,
-        root: Element | null,
         selector: string,
         elements: Element[]
       ) {
-        expect(page[DOM_QUERY].root).toEqual(root);
-        expect(page[DOM_QUERY].selector).toEqual(selector);
+        expect(page[DOM_QUERY].root).toEqual(document.body);
+        expect(page[DOM_QUERY].selectorArray.toString()).toEqual(selector);
         expect(page.element).toEqual(page[DOM_QUERY].query());
         expect(page.elements).toEqual(page[DOM_QUERY].queryAll());
         expect(page.element).toEqual(elements[0] || null);
         expect(page.elements).toEqual(elements);
       }
 
-      checkQuery(new PageObject(), document.body, '', [document.body]);
-      checkQuery(new PageObject('div', null, 1), div2, '', [div2]);
-      checkQuery(new PageObject('div', null, 2), null, '', []);
-      checkQuery(
-        new PageObject('div', new PageObject()),
-        document.body,
-        'div',
-        [div1, div2]
-      );
-      checkQuery(new PageObject('div', new PageObject(), 1), div2, '', [div2]);
-      checkQuery(new PageObject('div', new PageObject(), 2), null, '', []);
+      checkQuery(new PageObject(), '', [document.body]);
+      checkQuery(new PageObject('div', null, 1), 'div[1]', [div2]);
+      checkQuery(new PageObject('div', null, 2), 'div[2]', []);
+      checkQuery(new PageObject('div', new PageObject()), 'div', [div1, div2]);
+      checkQuery(new PageObject('div', new PageObject(), 1), 'div[1]', [div2]);
+      checkQuery(new PageObject('div', new PageObject(), 2), 'div[2]', []);
     });
 
-    describe('with no parent', () => {
-      describe('without a selector', () => {
-        test('element defaults to body', () => {
+    describe('root', () => {
+      describe('without parent', () => {
+        test('defaults to body', () => {
           let page = new PageObject();
           expect(page[DOM_QUERY].root).toEqual(document.body);
-          expect(page[DOM_QUERY].selector).toEqual('');
         });
 
-        test('element respects setRoot(Element)', () => {
+        test('respects setRoot()', () => {
           document.body.innerHTML = '<div></div>';
           let div = document.body.children[0];
 
@@ -56,237 +49,309 @@ describe('PageObject', () => {
 
           let page = new PageObject();
           expect(page[DOM_QUERY].root).toEqual(div);
-          expect(page[DOM_QUERY].selector).toEqual('');
-        });
-
-        test('it can have an index', () => {
-          let page = new PageObject('', null, 0);
-          expect(page[DOM_QUERY].root).toEqual(document.body);
-          expect(page[DOM_QUERY].selector).toEqual('');
-
-          page = new PageObject('', null, 1);
-          expect(page[DOM_QUERY].root).toEqual(null);
-          expect(page[DOM_QUERY].selector).toEqual('');
-        });
-
-        test('it can clone with index', () => {
-          let page = new PageObject();
-
-          let page0 = page[CLONE_WITH_INDEX](0);
-          expect(page0[DOM_QUERY].root).toEqual(document.body);
-          expect(page0[DOM_QUERY].selector).toEqual('');
-
-          let page1 = page[CLONE_WITH_INDEX](1);
-          expect(page1[DOM_QUERY].root).toEqual(null);
-          expect(page1[DOM_QUERY].selector).toEqual('');
         });
       });
 
-      describe('with a selector', () => {
-        test('it works', () => {
-          let page = new PageObject('div');
-          expect(page[DOM_QUERY].root).toEqual(document.body);
-          expect(page[DOM_QUERY].selector).toEqual('div');
-        });
-
-        test('it can have an index', () => {
-          document.body.innerHTML = '<div></div><div></div>';
-          let [div1, div2] = Array.from(document.body.children);
-
-          let page = new PageObject('div', null, 0);
-          expect(page[DOM_QUERY].root).toEqual(div1);
-          expect(page[DOM_QUERY].selector).toEqual('');
-
-          page = new PageObject('div', null, 1);
-          expect(page[DOM_QUERY].root).toEqual(div2);
-          expect(page[DOM_QUERY].selector).toEqual('');
-
-          page = new PageObject('div', null, 2);
-          expect(page[DOM_QUERY].root).toEqual(null);
-          expect(page[DOM_QUERY].selector).toEqual('');
-        });
-
-        test('it can clone with index', () => {
-          document.body.innerHTML = '<div></div><div></div>';
-          let [div1, div2] = Array.from(document.body.children);
-
-          let page = new PageObject('div');
-
-          let page0 = page[CLONE_WITH_INDEX](0);
-          expect(page0[DOM_QUERY].root).toEqual(div1);
-          expect(page0[DOM_QUERY].selector).toEqual('');
-
-          let page1 = page[CLONE_WITH_INDEX](1);
-          expect(page1[DOM_QUERY].root).toEqual(div2);
-          expect(page1[DOM_QUERY].selector).toEqual('');
-
-          let page2 = page[CLONE_WITH_INDEX](2);
-          expect(page2[DOM_QUERY].root).toEqual(null);
-          expect(page2[DOM_QUERY].selector).toEqual('');
-        });
-      });
-    });
-
-    describe('with an element parent', () => {
-      test('it works', () => {
-        document.body.innerHTML = '<span></span>';
-        let span = document.body.children[0];
-
-        let page = new PageObject('div', span);
-        expect(page[DOM_QUERY].root).toEqual(span);
-        expect(page[DOM_QUERY].selector).toEqual('div');
-      });
-
-      test('it can have an index', () => {
-        document.body.innerHTML = `
-          <span>
-            <div></div>
-            <div></div>
-          </span>
-          <div></div>
-        `;
-        let span = document.body.children[0];
-        let [div1, div2] = Array.from(span.children);
-
-        let page = new PageObject('div', span, 0);
-        expect(page[DOM_QUERY].root).toEqual(div1);
-        expect(page[DOM_QUERY].selector).toEqual('');
-
-        page = new PageObject('div', span, 1);
-        expect(page[DOM_QUERY].root).toEqual(div2);
-        expect(page[DOM_QUERY].selector).toEqual('');
-
-        page = new PageObject('div', span, 2);
-        expect(page[DOM_QUERY].root).toEqual(null);
-        expect(page[DOM_QUERY].selector).toEqual('');
-      });
-
-      test('it can clone with index', () => {
-        document.body.innerHTML = `
-          <span>
-            <div></div>
-            <div></div>
-          </span>
-          <div></div>
-        `;
-        let span = document.body.children[0];
-        let [div1, div2] = Array.from(span.children);
-
-        let page = new PageObject('div', span);
-
-        let page0 = page[CLONE_WITH_INDEX](0);
-        expect(page0[DOM_QUERY].root).toEqual(div1);
-        expect(page0[DOM_QUERY].selector).toEqual('');
-
-        let page1 = page[CLONE_WITH_INDEX](1);
-        expect(page1[DOM_QUERY].root).toEqual(div2);
-        expect(page1[DOM_QUERY].selector).toEqual('');
-
-        let page2 = page[CLONE_WITH_INDEX](2);
-        expect(page2[DOM_QUERY].root).toEqual(null);
-        expect(page2[DOM_QUERY].selector).toEqual('');
-      });
-    });
-
-    describe('with a PageObject parent', () => {
-      describe('parent without selector', () => {
-        test('it works', () => {
+      describe('with parent', () => {
+        test('defaults to body', () => {
           let parent = new PageObject();
-
-          let page = new PageObject('div', parent);
+          let page = new PageObject('', parent);
           expect(page[DOM_QUERY].root).toEqual(document.body);
-          expect(page[DOM_QUERY].selector).toEqual('div');
         });
 
-        test('it can have an index', () => {
-          document.body.innerHTML = '<div></div><div></div>';
-          let [div1, div2] = Array.from(document.body.children);
-
-          let parent = new PageObject();
-
-          let page = new PageObject('div', parent, 0);
-          expect(page[DOM_QUERY].root).toEqual(div1);
-          expect(page[DOM_QUERY].selector).toEqual('');
-
-          page = new PageObject('div', parent, 1);
-          expect(page[DOM_QUERY].root).toEqual(div2);
-          expect(page[DOM_QUERY].selector).toEqual('');
-
-          page = new PageObject('div', parent, 2);
-          expect(page[DOM_QUERY].root).toEqual(null);
-          expect(page[DOM_QUERY].selector).toEqual('');
-        });
-
-        test('it can clone with index', () => {
-          document.body.innerHTML = '<div></div><div></div>';
-          let [div1, div2] = Array.from(document.body.children);
-
-          let parent = new PageObject();
-          let page = new PageObject('div', parent);
-
-          let page0 = page[CLONE_WITH_INDEX](0);
-          expect(page0[DOM_QUERY].root).toEqual(div1);
-          expect(page0[DOM_QUERY].selector).toEqual('');
-
-          let page1 = page[CLONE_WITH_INDEX](1);
-          expect(page1[DOM_QUERY].root).toEqual(div2);
-          expect(page1[DOM_QUERY].selector).toEqual('');
-
-          let page2 = page[CLONE_WITH_INDEX](2);
-          expect(page2[DOM_QUERY].root).toEqual(null);
-          expect(page2[DOM_QUERY].selector).toEqual('');
-        });
-      });
-
-      describe('parent with selector', () => {
-        test('it works', () => {
+        test('respects setRoot()', () => {
           document.body.innerHTML = '<div></div>';
+          let div = document.body.children[0];
 
-          let parent = new PageObject('div');
-          let page = new PageObject('span', parent);
-          expect(page[DOM_QUERY].root).toEqual(document.body);
-          expect(page[DOM_QUERY].selector).toEqual('div span');
+          setRoot(div);
+
+          let parent = new PageObject();
+          let page = new PageObject('', parent);
+          expect(page[DOM_QUERY].root).toEqual(div);
+        });
+
+        test('is parent when parent is element', () => {
+          document.body.innerHTML = '<div></div>';
+          let div = document.body.children[0];
+
+          let page = new PageObject('', div);
+          expect(page[DOM_QUERY].root).toEqual(div);
+        });
+
+        test('inherits parent root when grandparent is element', () => {
+          document.body.innerHTML = '<div></div>';
+          let div = document.body.children[0];
+
+          let parent = new PageObject('', div);
+          let page = new PageObject('', parent);
+          expect(page[DOM_QUERY].root).toEqual(div);
+
+          page = parent[CLONE_WITH_INDEX](0);
+          expect(page[DOM_QUERY].root).toEqual(div);
+        });
+      });
+    });
+
+    describe('selector array', () => {
+      describe('with no parent', () => {
+        describe('without a selector', () => {
+          test('it can have an index', () => {
+            let page = new PageObject('', null, 0);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual('[0]');
+
+            page = new PageObject('', null, 1);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual('[1]');
+          });
+
+          test('it can clone with index', () => {
+            let page = new PageObject();
+
+            let page0 = page[CLONE_WITH_INDEX](0);
+            expect(page0[DOM_QUERY].selectorArray.toString()).toEqual('[0]');
+
+            let page1 = page[CLONE_WITH_INDEX](1);
+            expect(page1[DOM_QUERY].selectorArray.toString()).toEqual('[1]');
+          });
+        });
+
+        describe('with a selector', () => {
+          test('it works', () => {
+            let page = new PageObject('div');
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual('div');
+          });
+
+          test('it can have an index', () => {
+            document.body.innerHTML = '<div></div><div></div>';
+
+            let page = new PageObject('div', null, 0);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual('div[0]');
+
+            page = new PageObject('div', null, 1);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual('div[1]');
+
+            page = new PageObject('div', null, 2);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual('div[2]');
+          });
+
+          test('it can clone with index', () => {
+            document.body.innerHTML = '<div></div><div></div>';
+
+            let page = new PageObject('div');
+
+            let page0 = page[CLONE_WITH_INDEX](0);
+            expect(page0[DOM_QUERY].selectorArray.toString()).toEqual('div[0]');
+
+            let page1 = page[CLONE_WITH_INDEX](1);
+            expect(page1[DOM_QUERY].selectorArray.toString()).toEqual('div[1]');
+
+            let page2 = page[CLONE_WITH_INDEX](2);
+            expect(page2[DOM_QUERY].selectorArray.toString()).toEqual('div[2]');
+          });
+        });
+      });
+
+      describe('with an element parent', () => {
+        test('it works', () => {
+          document.body.innerHTML = '<span></span>';
+          let span = document.body.children[0];
+
+          let page = new PageObject('div', span);
+          expect(page[DOM_QUERY].selectorArray.toString()).toEqual('div');
         });
 
         test('it can have an index', () => {
-          document.body.innerHTML = '<div><span></span><span></span></div>';
-          let div = document.body.children[0];
-          let [span1, span2] = Array.from(div.children);
+          document.body.innerHTML = `
+            <span>
+              <div></div>
+              <div></div>
+            </span>
+            <div></div>
+          `;
+          let span = document.body.children[0];
 
-          let parent = new PageObject('div');
+          let page = new PageObject('div', span, 0);
+          expect(page[DOM_QUERY].selectorArray.toString()).toEqual('div[0]');
 
-          let page = new PageObject('span', parent, 0);
-          expect(page[DOM_QUERY].root).toEqual(span1);
-          expect(page[DOM_QUERY].selector).toEqual('');
+          page = new PageObject('div', span, 1);
+          expect(page[DOM_QUERY].selectorArray.toString()).toEqual('div[1]');
 
-          page = new PageObject('span', parent, 1);
-          expect(page[DOM_QUERY].root).toEqual(span2);
-          expect(page[DOM_QUERY].selector).toEqual('');
-
-          page = new PageObject('span', parent, 2);
-          expect(page[DOM_QUERY].root).toEqual(null);
-          expect(page[DOM_QUERY].selector).toEqual('');
+          page = new PageObject('div', span, 2);
+          expect(page[DOM_QUERY].selectorArray.toString()).toEqual('div[2]');
         });
 
         test('it can clone with index', () => {
-          document.body.innerHTML = '<div><span></span><span></span></div>';
-          let div = document.body.children[0];
-          let [span1, span2] = Array.from(div.children);
+          document.body.innerHTML = `
+            <span>
+              <div></div>
+              <div></div>
+            </span>
+            <div></div>
+          `;
+          let span = document.body.children[0];
 
-          let parent = new PageObject('div');
-          let page = new PageObject('span', parent);
+          let page = new PageObject('div', span);
 
           let page0 = page[CLONE_WITH_INDEX](0);
-          expect(page0[DOM_QUERY].root).toEqual(span1);
-          expect(page0[DOM_QUERY].selector).toEqual('');
+          expect(page0[DOM_QUERY].selectorArray.toString()).toEqual('div[0]');
 
           let page1 = page[CLONE_WITH_INDEX](1);
-          expect(page1[DOM_QUERY].root).toEqual(span2);
-          expect(page1[DOM_QUERY].selector).toEqual('');
+          expect(page1[DOM_QUERY].selectorArray.toString()).toEqual('div[1]');
 
           let page2 = page[CLONE_WITH_INDEX](2);
-          expect(page2[DOM_QUERY].root).toEqual(null);
-          expect(page2[DOM_QUERY].selector).toEqual('');
+          expect(page2[DOM_QUERY].selectorArray.toString()).toEqual('div[2]');
+        });
+      });
+
+      describe('with a PageObject parent', () => {
+        describe('parent without selector', () => {
+          test('it works', () => {
+            let parent = new PageObject();
+
+            let page = new PageObject('div', parent);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual('div');
+          });
+
+          test('it can have an index', () => {
+            document.body.innerHTML = '<div></div><div></div>';
+
+            let parent = new PageObject();
+
+            let page = new PageObject('div', parent, 0);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual('div[0]');
+
+            page = new PageObject('div', parent, 1);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual('div[1]');
+
+            page = new PageObject('div', parent, 2);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual('div[2]');
+          });
+
+          test('it can clone with index', () => {
+            document.body.innerHTML = '<div></div><div></div>';
+
+            let parent = new PageObject();
+            let page = new PageObject('div', parent);
+
+            let page0 = page[CLONE_WITH_INDEX](0);
+            expect(page0[DOM_QUERY].selectorArray.toString()).toEqual('div[0]');
+
+            let page1 = page[CLONE_WITH_INDEX](1);
+            expect(page1[DOM_QUERY].selectorArray.toString()).toEqual('div[1]');
+
+            let page2 = page[CLONE_WITH_INDEX](2);
+            expect(page2[DOM_QUERY].selectorArray.toString()).toEqual('div[2]');
+          });
+        });
+
+        describe('parent with selector', () => {
+          test('it works', () => {
+            document.body.innerHTML = '<div></div>';
+
+            let parent = new PageObject('div');
+            let page = new PageObject('span', parent);
+            expect(page[DOM_QUERY].root).toEqual(document.body);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual(
+              'div span'
+            );
+          });
+
+          test('it can have an index', () => {
+            document.body.innerHTML = '<div><span></span><span></span></div>';
+
+            let parent = new PageObject('div');
+
+            let page = new PageObject('span', parent, 0);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual(
+              'div span[0]'
+            );
+
+            page = new PageObject('span', parent, 1);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual(
+              'div span[1]'
+            );
+
+            page = new PageObject('span', parent, 2);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual(
+              'div span[2]'
+            );
+          });
+
+          test('it can clone with index', () => {
+            document.body.innerHTML = '<div><span></span><span></span></div>';
+
+            let parent = new PageObject('div');
+            let page = new PageObject('span', parent);
+
+            let page0 = page[CLONE_WITH_INDEX](0);
+            expect(page0[DOM_QUERY].selectorArray.toString()).toEqual(
+              'div span[0]'
+            );
+
+            let page1 = page[CLONE_WITH_INDEX](1);
+            expect(page1[DOM_QUERY].selectorArray.toString()).toEqual(
+              'div span[1]'
+            );
+
+            let page2 = page[CLONE_WITH_INDEX](2);
+            expect(page2[DOM_QUERY].selectorArray.toString()).toEqual(
+              'div span[2]'
+            );
+          });
+        });
+
+        describe('parent with selector and index', () => {
+          test('it works', () => {
+            document.body.innerHTML = '<div></div><div></div>';
+
+            let parent = new PageObject('div', null, 1);
+            let page = new PageObject('span', parent);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual(
+              'div[1] span'
+            );
+          });
+
+          test('it can have an index', () => {
+            document.body.innerHTML = '<div><span></span><span></span></div>';
+
+            let parent = new PageObject('div', null, 1);
+
+            let page = new PageObject('span', parent, 0);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual(
+              'div[1] span[0]'
+            );
+
+            page = new PageObject('span', parent, 1);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual(
+              'div[1] span[1]'
+            );
+
+            page = new PageObject('span', parent, 2);
+            expect(page[DOM_QUERY].selectorArray.toString()).toEqual(
+              'div[1] span[2]'
+            );
+          });
+
+          test('it can clone with index', () => {
+            document.body.innerHTML = '<div><span></span><span></span></div>';
+
+            let parent = new PageObject('div', null, 1);
+            let page = new PageObject('span', parent);
+
+            let page0 = page[CLONE_WITH_INDEX](0);
+            expect(page0[DOM_QUERY].selectorArray.toString()).toEqual(
+              'div[1] span[0]'
+            );
+
+            let page1 = page[CLONE_WITH_INDEX](1);
+            expect(page1[DOM_QUERY].selectorArray.toString()).toEqual(
+              'div[1] span[1]'
+            );
+
+            let page2 = page[CLONE_WITH_INDEX](2);
+            expect(page2[DOM_QUERY].selectorArray.toString()).toEqual(
+              'div[1] span[2]'
+            );
+          });
         });
       });
     });

--- a/packages/fractal-page-object/src/global-selector.ts
+++ b/packages/fractal-page-object/src/global-selector.ts
@@ -129,7 +129,8 @@ export default function globalSelector<T extends PageObject>(
  * page.listItems[0]; // testContainer.querySelectorAll('.listItems')[0]
  * page.listItems[0].popover; // document.body.querySelectorAll('.popover')
  * page.listItems[0].popover.icon; // document.body.querySelectorAll('.popover .icon')
- */ export default function globalSelector<T extends PageObject>(
+ */
+export default function globalSelector<T extends PageObject>(
   ...args: Arguments<T> | ArgumentsWithRoot<T>
 ): T {
   let selector = args[0];

--- a/packages/fractal-page-object/src/page-object.ts
+++ b/packages/fractal-page-object/src/page-object.ts
@@ -121,9 +121,9 @@ export default class PageObject extends ArrayStub {
     if (this.parent instanceof PageObject) {
       parentQuery = this.parent[DOM_QUERY];
     } else if (this.parent instanceof Element) {
-      parentQuery = new DOMQuery(this.parent, '');
+      parentQuery = new DOMQuery(this.parent);
     } else {
-      parentQuery = new DOMQuery(getRoot(), '');
+      parentQuery = new DOMQuery(getRoot());
     }
     return parentQuery.createChild(this.selector, this.index);
   }
@@ -141,37 +141,8 @@ export default class PageObject extends ArrayStub {
    * @private
    */
   [CLONE_WITH_INDEX](index: number): PageObject {
-    // We have to be careful about how we treat the index. If this page object
-    // already has an index, then it only matches 0 elements or 1 element, so
-    // cloning it with a new index can only possibly match an element if that
-    // new index is 0. For example, suppose `pageObject` matched two DOM
-    // elements. Then `pageObject[0]` would match only the first DOM element,
-    // and `pageObject[0][0]` would match that same DOM element, while
-    // `pageObject[0][1]` wouldn't match any DOM element. So we need to factor
-    // in this page object's index when determining what index in the full query
-    // result set the passed-in index is actually referring to.
-    let resolvedIndex;
-    if (this.index === null) {
-      // No index, so the index stays as provided
-      resolvedIndex = index;
-    } else {
-      // We have an index. So if the provided index is 0, the clone should match
-      // the same element as this page object, and should get the same index. If
-      // the provided index is anything else, it can never match any DOM elements,
-      // so we'll give the clone an index of -1 so it never matches.
-      if (index === 0) {
-        resolvedIndex = this.index;
-      } else {
-        resolvedIndex = -1;
-      }
-    }
     let Class = this.constructor as PageObjectClass<PageObject>;
-    return new Class(
-      this.selector,
-      this.parent,
-      resolvedIndex,
-      this.rootElement
-    );
+    return new Class('', this, index, this.rootElement);
   }
 
   /**


### PR DESCRIPTION
Previously DOM queries weren't fully lazy -- when doing an indexing operation, we would execute a DOM query to get it results, index into them, and create a new root for the child DOM query.

This change defers that until actually executing the child query. So, rather than a DOMQuery's data consisting of a root element and a single selector, it consists of a root element and a selector array that trackes the selectors/indices involves in the query so it can defer any evaluation (querying the actual DOM) until the query is actually executed.

This allows more flexibility in creating PageObjects before the DOM is populated, and also paves the way for async DOM queries (to support webdriver-like test environments).