### PR TITLE
Support overriding array API

### DIFF
--- a/packages/fractal-page-object/src/-private/array-stub.ts
+++ b/packages/fractal-page-object/src/-private/array-stub.ts
@@ -36,191 +36,111 @@ export default class ArrayStub {
   /**
    * @private
    */
-  readonly length: number = 0;
+  declare readonly length: number;
   /**
    * @private
    */
-  pop(): WithElement<this> | undefined {
-    return undefined;
-  }
+  declare pop: () => WithElement<this> | undefined;
   /**
    * @private
    */
-  concat(...items: ConcatArray<WithElement<this>>[]): WithElement<this>[];
+  declare concat: (
+    ...items:
+      | ConcatArray<WithElement<this>>[]
+      | (WithElement<this> | ConcatArray<WithElement<this>>)[]
+      | (WithElement<this> | ConcatArray<WithElement<this>>)[]
+  ) => WithElement<this>[];
   /**
    * @private
    */
-  concat(
-    ...items: (WithElement<this> | ConcatArray<WithElement<this>>)[]
-  ): WithElement<this>[];
+  declare reverse: () => WithElement<this>[];
   /**
    * @private
    */
-  concat(
-    ..._items: (WithElement<this> | ConcatArray<WithElement<this>>)[]
-  ): WithElement<this>[] {
-    return [];
-  }
+  declare shift: () => WithElement<this> | undefined;
   /**
    * @private
    */
-  reverse(): WithElement<this>[] {
-    return [];
-  }
+  declare slice: (_start?: number, _end?: number) => WithElement<this>[];
   /**
    * @private
    */
-  shift(): WithElement<this> | undefined {
-    return undefined;
-  }
-  /**
-   * @private
-   */
-  slice(_start?: number, _end?: number): WithElement<this>[] {
-    return [];
-  }
-  /**
-   * @private
-   */
-  sort(
+  declare sort: (
     _compareFn?: (a: WithElement<this>, b: WithElement<this>) => number
-  ): this[] {
-    return [];
-  }
+  ) => this[];
   /**
    * @private
    */
-  indexOf(_searchElement: WithElement<this>, _fromIndex?: number): number {
-    return -1;
-  }
+  declare indexOf: (
+    _searchElement: WithElement<this>,
+    _fromIndex?: number
+  ) => number;
   /**
    * @private
    */
-  lastIndexOf(_searchElement: WithElement<this>, _fromIndex?: number): number {
-    return -1;
-  }
+  declare lastIndexOf: (
+    _searchElement: WithElement<this>,
+    _fromIndex?: number
+  ) => number;
   /**
    * @private
    */
-  every<S extends WithElement<this>>(
-    predicate: (
-      value: WithElement<this>,
-      index: number,
-      array: WithElement<this>[]
-    ) => value is S,
-    thisArg?: any
-  ): this is S[];
-  /**
-   * @private
-   */
-  every(
+  declare every: (
     predicate: (
       value: WithElement<this>,
       index: number,
       array: WithElement<this>[]
     ) => unknown,
     _thisArg?: any
-  ): boolean;
+  ) => boolean;
   /**
    * @private
    */
-  every(
-    predicate: (
-      value: WithElement<this>,
-      index: number,
-      array: WithElement<this>[]
-    ) => unknown,
-    _thisArg?: any
-  ): boolean;
-  /**
-   * @private
-   */
-  every(
+  declare some: (
     _predicate: (
       value: WithElement<this>,
       index: number,
       array: WithElement<this>[]
     ) => unknown,
     _thisArg?: any
-  ): boolean {
-    return false;
-  }
+  ) => boolean;
   /**
    * @private
    */
-  some(
-    _predicate: (
-      value: WithElement<this>,
-      index: number,
-      array: WithElement<this>[]
-    ) => unknown,
-    _thisArg?: any
-  ): boolean {
-    return false;
-  }
-  /**
-   * @private
-   */
-  forEach(
+  declare forEach: (
     _callbackfn: (
       value: WithElement<this>,
       index: number,
       array: WithElement<this>[]
     ) => void,
     _thisArg?: any
-  ): void {}
+  ) => void;
   /**
    * @private
    */
-  map<U>(
+  declare map: <U>(
     _callbackfn: (
       value: WithElement<this>,
       index: number,
       array: WithElement<this>[]
     ) => U,
     _thisArg?: any
-  ): U[] {
-    return [];
-  }
+  ) => U[];
   /**
    * @private
    */
-  filter<S extends WithElement<this>>(
-    predicate: (
-      value: WithElement<this>,
-      index: number,
-      array: WithElement<this>[]
-    ) => value is S,
-    thisArg?: any
-  ): S[];
-  /**
-   * @private
-   */
-  filter(
+  declare filter: (
     predicate: (
       value: WithElement<this>,
       index: number,
       array: WithElement<this>[]
     ) => unknown,
     thisArg?: any
-  ): WithElement<this>[];
+  ) => WithElement<this>[];
   /**
    * @private
    */
-  filter(
-    _predicate: (
-      value: WithElement<this>,
-      index: number,
-      array: WithElement<this>[]
-    ) => unknown,
-    _thisArg?: any
-  ): WithElement<this>[] {
-    return [];
-  }
-  /**
-   * @private
-   */
-  reduce<U>(
+  declare reduce: <U>(
     _callbackfn: (
       previousValue: U,
       currentValue: WithElement<this>,
@@ -228,13 +148,11 @@ export default class ArrayStub {
       array: WithElement<this>[]
     ) => U,
     initialValue: U
-  ): U {
-    return initialValue;
-  }
+  ) => U;
   /**
    * @private
    */
-  reduceRight<U>(
+  declare reduceRight: <U>(
     _callbackfn: (
       previousValue: U,
       currentValue: WithElement<this>,
@@ -242,88 +160,52 @@ export default class ArrayStub {
       array: WithElement<this>[]
     ) => U,
     initialValue: U
-  ): U {
-    return initialValue;
-  }
+  ) => U;
   /**
    * @private
    */
-  find<S extends WithElement<this>>(
-    predicate: (
-      this: void,
-      value: WithElement<this>,
-      index: number,
-      obj: WithElement<this>[]
-    ) => value is S,
-    thisArg?: any
-  ): S | undefined;
-  /**
-   * @private
-   */
-  find(
+  declare find: (
     predicate: (
       value: WithElement<this>,
       index: number,
       obj: WithElement<this>[]
     ) => unknown,
     thisArg?: any
-  ): WithElement<this> | undefined;
+  ) => WithElement<this> | undefined;
   /**
    * @private
    */
-  find(
+  declare findIndex: (
     _predicate: (
       value: WithElement<this>,
       index: number,
       obj: WithElement<this>[]
     ) => unknown,
     _thisArg?: any
-  ): WithElement<this> | undefined {
-    return undefined;
-  }
+  ) => number;
   /**
    * @private
    */
-  findIndex(
-    _predicate: (
-      value: WithElement<this>,
-      index: number,
-      obj: WithElement<this>[]
-    ) => unknown,
-    _thisArg?: any
-  ): number {
-    return -1;
-  }
+  declare includes: (
+    _searchElement: WithElement<this>,
+    _fromIndex?: number
+  ) => boolean;
   /**
    * @private
    */
-  includes(_searchElement: WithElement<this>, _fromIndex?: number): boolean {
-    return false;
-  }
+  declare [Symbol.iterator]: () => IterableIterator<WithElement<this>>;
   /**
    * @private
    */
-  [Symbol.iterator](): IterableIterator<WithElement<this>> {
-    return {} as IterableIterator<WithElement<this>>;
-  }
+  declare entries: () => IterableIterator<[number, WithElement<this>]>;
   /**
    * @private
    */
-  entries(): IterableIterator<[number, WithElement<this>]> {
-    return {} as IterableIterator<[number, WithElement<this>]>;
-  }
+  declare keys: () => IterableIterator<number>;
   /**
    * @private
    */
-  keys(): IterableIterator<number> {
-    return {} as IterableIterator<number>;
-  }
-  /**
-   * @private
-   */
-  values(): IterableIterator<WithElement<this>> {
-    return {} as IterableIterator<WithElement<this>>;
-  }
+  declare values: () => IterableIterator<WithElement<this>>;
 
   /**
    * @private

--- a/packages/fractal-page-object/src/__tests__/page-object.ts
+++ b/packages/fractal-page-object/src/__tests__/page-object.ts
@@ -381,6 +381,10 @@ describe('PageObject', () => {
       );
       expect(empty.find((o) => o.element.id === 'span2')).toEqual(undefined);
       expect(
+        page.filter((o) => o.element.id === 'span2').map((o) => o.element)
+      ).toEqual([span2]);
+      expect(empty.filter((o) => o.element.id === 'span2')).toEqual([]);
+      expect(
         page
           .sort(
             (a, b) =>
@@ -599,6 +603,17 @@ describe('PageObject', () => {
       expect(page[3].customProp).toEqual('val');
       expect(page.map((o) => o.constructor)).toEqual([Page, Page]);
       expect(page.map((o) => o.customProp)).toEqual(['val', 'val']);
+    });
+
+    test('overriding members of the array API works', () => {
+      class Page extends PageObject {
+        // @ts-expect-error
+        filter() {
+          return 'byName';
+        }
+      }
+      let page = new Page('div');
+      expect(page.filter()).toEqual('byName');
     });
   });
 


### PR DESCRIPTION
Previously overriding array API methods could get you into serious trouble. We would call the array method instead of the PageObject subclass method, and if the arguments weren't compatible, methods like `filter()` would blow up because they weren't passed a proper callback. Typescript would warn about this, but plain js would not.

So, make a couple of improvements:

1. Change the ArrayStub base class (whose job is to expose the array types on PageObject) to declare all of its members instead of implementing them
2. Reverse the proxy behavior to first check the PageObject, and only if it doesn't implement the requested property, check for an array implementation. This wasn't previously possible because all array methods were actually present on the PageObject itself. But now that they are declared, we get the typing benefits, but at runtime can distinguish PageObject properties/methods from array properties/methods