### PR TITLE
Export PageObjectConstructor type

### DIFF
--- a/packages/fractal-page-object/src/-private/factory.ts
+++ b/packages/fractal-page-object/src/-private/factory.ts
@@ -1,4 +1,4 @@
-import type { PageObjectClass } from './types';
+import type { PageObjectConstructor } from './types';
 import PageObject from '../page-object';
 
 /**
@@ -14,7 +14,10 @@ export default class PageObjectFactory<T extends PageObject> {
    * subclass of {@link PageObject}. If not supplied, {@link PageObject} will be
    * used.
    */
-  constructor(private selector: string, private Class?: PageObjectClass<T>) {}
+  constructor(
+    private selector: string,
+    private Class?: PageObjectConstructor<T>
+  ) {}
 
   /**
    * Create a {@link PageObject}
@@ -23,7 +26,7 @@ export default class PageObjectFactory<T extends PageObject> {
    * @returns the new page object
    */
   create(parent?: PageObject | Element): PageObject {
-    let Class = this.Class || (PageObject as PageObjectClass<PageObject>);
+    let Class = this.Class || (PageObject as PageObjectConstructor<PageObject>);
     return new Class(this.selector, parent);
   }
 }

--- a/packages/fractal-page-object/src/-private/global-factory.ts
+++ b/packages/fractal-page-object/src/-private/global-factory.ts
@@ -1,4 +1,4 @@
-import type { PageObjectClass } from './types';
+import type { PageObjectConstructor } from './types';
 import PageObject from '../page-object';
 import Factory from './factory';
 
@@ -22,7 +22,7 @@ export default class GlobalPageObjectFactory<
   constructor(
     selector: string,
     private rootElement?: Element,
-    Class?: PageObjectClass<T>
+    Class?: PageObjectConstructor<T>
   ) {
     super(selector, Class);
   }

--- a/packages/fractal-page-object/src/-private/helpers.ts
+++ b/packages/fractal-page-object/src/-private/helpers.ts
@@ -1,13 +1,15 @@
 import PageObject from '../page-object';
-import type { PageObjectClass } from './types';
+import type { PageObjectConstructor } from './types';
 
-function isPageObjectSubclass<T extends PageObject>(Class: PageObjectClass<T>) {
+function isPageObjectSubclass<T extends PageObject>(
+  Class: PageObjectConstructor<T>
+) {
   return Class === PageObject || Class.prototype instanceof PageObject;
 }
 
 export function validateSelectorArguments<T extends PageObject>(
   selector: string,
-  Class?: PageObjectClass<T>
+  Class?: PageObjectConstructor<T>
 ): void {
   if (!selector) {
     throw new Error('Cannot specify an empty selector');

--- a/packages/fractal-page-object/src/-private/types.ts
+++ b/packages/fractal-page-object/src/-private/types.ts
@@ -3,6 +3,9 @@ import type PageObject from '../page-object';
 export const DOM_QUERY = Symbol('DOM query');
 export const CLONE_WITH_INDEX = Symbol('withIndex');
 
-export type PageObjectClass<T extends PageObject> = new (
+/**
+ * A constructor for a {@link PageObject} or {@link PageObject} subclass
+ */
+export type PageObjectConstructor<T extends PageObject> = new (
   ...args: ConstructorParameters<typeof PageObject>
 ) => T | PageObject;

--- a/packages/fractal-page-object/src/global-selector.ts
+++ b/packages/fractal-page-object/src/global-selector.ts
@@ -1,13 +1,13 @@
 import GlobalPageObjectFactory from './-private/global-factory';
 import PageObject from './page-object';
-import type { PageObjectClass } from './-private/types';
+import type { PageObjectConstructor } from './-private/types';
 import { validateSelectorArguments } from './-private/helpers';
 
-type Arguments<T extends PageObject> = [string, PageObjectClass<T>?];
+type Arguments<T extends PageObject> = [string, PageObjectConstructor<T>?];
 type ArgumentsWithRoot<T extends PageObject> = [
   string,
   Element,
-  PageObjectClass<T>?
+  PageObjectConstructor<T>?
 ];
 
 /**
@@ -35,7 +35,7 @@ type ArgumentsWithRoot<T extends PageObject> = [
  */
 export default function globalSelector<T extends PageObject>(
   selector: string,
-  Class?: PageObjectClass<T>
+  Class?: PageObjectConstructor<T>
 ): T;
 
 /**
@@ -66,7 +66,7 @@ export default function globalSelector<T extends PageObject>(
 export default function globalSelector<T extends PageObject>(
   selector: string,
   rootElement: Element,
-  Class?: PageObjectClass<T>
+  Class?: PageObjectConstructor<T>
 ): T;
 
 /**

--- a/packages/fractal-page-object/src/index.ts
+++ b/packages/fractal-page-object/src/index.ts
@@ -1,4 +1,5 @@
 export { setRoot } from './-private/root';
+export type { PageObjectConstructor } from './-private/types';
 
 export { default as PageObject } from './page-object';
 

--- a/packages/fractal-page-object/src/page-object.ts
+++ b/packages/fractal-page-object/src/page-object.ts
@@ -3,7 +3,7 @@ import { getRoot } from './-private/root';
 import DOMQuery from './-private/dom-query';
 import createProxy from './-private/create-proxy';
 import { DOM_QUERY, CLONE_WITH_INDEX } from './-private/types';
-import type { PageObjectClass } from './-private/types';
+import type { PageObjectConstructor } from './-private/types';
 
 /**
  * This class implements all the basic page object functionality, and all page
@@ -141,7 +141,7 @@ export default class PageObject extends ArrayStub {
    * @private
    */
   [CLONE_WITH_INDEX](index: number): PageObject {
-    let Class = this.constructor as PageObjectClass<PageObject>;
+    let Class = this.constructor as PageObjectConstructor<PageObject>;
     return new Class('', this, index, this.rootElement);
   }
 

--- a/packages/fractal-page-object/src/selector.ts
+++ b/packages/fractal-page-object/src/selector.ts
@@ -1,6 +1,6 @@
 import PageObjectFactory from './-private/factory';
 import PageObject from './page-object';
-import type { PageObjectClass } from './-private/types';
+import type { PageObjectConstructor } from './-private/types';
 import { validateSelectorArguments } from './-private/helpers';
 
 /**
@@ -31,7 +31,7 @@ import { validateSelectorArguments } from './-private/helpers';
  */
 export default function selector<T extends PageObject>(
   selector: string,
-  Class?: PageObjectClass<T>
+  Class?: PageObjectConstructor<T>
 ): T {
   validateSelectorArguments(selector, Class);
 


### PR DESCRIPTION
Make it easier to created typed wrappers around selector() and globalSelector() by exporting the PageObjectConstructor type (renamed from the previously-private PageObjectClass type)

Fixes #16