### PR TITLE
Improve selector()/globalSelector() error checking

### DIFF
--- a/packages/fractal-page-object/src/-private/helpers.ts
+++ b/packages/fractal-page-object/src/-private/helpers.ts
@@ -14,9 +14,16 @@ export function validateSelectorArguments<T extends PageObject>(
   if (!selector) {
     throw new Error('Cannot specify an empty selector');
   }
+
+  try {
+    document.querySelector(selector);
+  } catch (e) {
+    throw new Error(`Selector is invalid: ${selector}`);
+  }
+
   if (Class && !isPageObjectSubclass(Class)) {
     throw new Error(
-      'Custom globalSelector() class must be PageObject or PageObject subclass'
+      'Custom selector()/globalSelector() class must be PageObject or PageObject subclass'
     );
   }
 }

--- a/packages/fractal-page-object/src/__tests__/global-selector.ts
+++ b/packages/fractal-page-object/src/__tests__/global-selector.ts
@@ -5,8 +5,9 @@ import { resetRoot } from '../-private/root';
 describe('globalSelector()', () => {
   afterEach(() => resetRoot());
 
-  test('it requires a selector and the class must be a PageObject subclass', () => {
+  test('it requires a valid selector and the class must be a PageObject subclass', () => {
     expect(() => globalSelector('')).toThrow();
+    expect(() => globalSelector('  ')).toThrow();
     // @ts-expect-error violate types to make sure validation throws
     expect(() => globalSelector('', class {})).toThrow();
   });

--- a/packages/fractal-page-object/src/__tests__/selector.ts
+++ b/packages/fractal-page-object/src/__tests__/selector.ts
@@ -2,8 +2,9 @@ import { describe, test, expect } from '@jest/globals';
 import { selector, PageObject } from '..';
 
 describe('selector()', () => {
-  test('it requires a selector and the class must be a PageObject subclass', () => {
+  test('it requires a valid selector and the class must be a PageObject subclass', () => {
     expect(() => selector('')).toThrow();
+    expect(() => selector('  ')).toThrow();
     // @ts-expect-error violate types to make sure validation throws
     expect(() => selector('div', class {})).toThrow();
   });


### PR DESCRIPTION
Validate that the selector is a valid selector immediately (rather than waiting until the property is accessed the the DOMQuery throws an error), and improve the error message of the non-PageObject-class case