### PR TITLE
Support "scoped selectors"

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ let page = new WelcomePage();
 
 Note the use of `querySelectorAll()` rather than `querySelector()` -- this is because, like CSS selectors, how you use page objects determines whether they resolve to the first matching element or all matching elements. Unlike CSS selectors, though, page objects can accommodate list indexing, analagous to the `:eq()` `jQuery` extension.
 
+`selector()` also supports some strings that aren't valid CSS selectors, but can be used to build valid selectors, e.g. `> .email`. The rule is that a string passed to `selector()` is valid if it is itself a valid CSS selector, or if prepending `:scope ` to it would make it a valid CSS selector.
+
 #### Page objects as lists
 
 Page objects expose an array-like API -- they implement the index operator, the `Array` iteration methods such as `map()` and `find()`, and several other `Array` methods. The index operator always returns a page object, but one that is restricted to the element at the given index (if there is one).

--- a/packages/fractal-page-object/src/-private/dom-query.ts
+++ b/packages/fractal-page-object/src/-private/dom-query.ts
@@ -1,3 +1,5 @@
+import { safeSelector } from './helpers';
+
 /**
  * An element of a {@link SelectorArray}, comprising a selector and optional
  * index. This is to support a DOM query/selector language that allows indexing.
@@ -90,7 +92,7 @@ export default class DOMQuery {
       if (index !== undefined) {
         if (selector) {
           // Selector and index, so query all and index into result set
-          el = el.querySelectorAll(selector)[index];
+          el = el.querySelectorAll(safeSelector(selector))[index];
         } else {
           // Only index, so index into the result set, which is just the current
           // element
@@ -98,7 +100,7 @@ export default class DOMQuery {
         }
       } else {
         // Only a selector
-        el = el.querySelector(selector);
+        el = el.querySelector(safeSelector(selector));
       }
     }
     return el || null;
@@ -122,7 +124,7 @@ export default class DOMQuery {
         let el;
         if (selector) {
           // Selector and index, so query all and index into the result set
-          el = matches[0].querySelectorAll(selector)[index];
+          el = matches[0].querySelectorAll(safeSelector(selector))[index];
         } else {
           // Only index, so index into the result set, which is just the current
           // element
@@ -132,7 +134,9 @@ export default class DOMQuery {
         matches = el ? [el] : [];
       } else {
         // Only a selector, so query for result set and covert to array
-        matches = Array.from(matches[0].querySelectorAll(selector));
+        matches = Array.from(
+          matches[0].querySelectorAll(safeSelector(selector))
+        );
       }
     }
     return matches;

--- a/packages/fractal-page-object/src/__tests__/dom-query.ts
+++ b/packages/fractal-page-object/src/__tests__/dom-query.ts
@@ -5,23 +5,42 @@ describe('DOMQuery', () => {
   let root = document.querySelector('div');
   let span1: Element;
   let span2: Element;
+  let nestedSpan1: Element;
+  let nestedSpan2: Element;
   let strong1: Element;
   let strong2: Element;
   let strong3: Element;
   let strong4: Element;
+  let nestedStrong1: Element;
+  let nestedStrong2: Element;
+  let nestedStrong3: Element;
+  let nestedStrong4: Element;
+  let nestedStrong5: Element;
   let rootQuery: DOMQuery;
 
   beforeEach(() => {
     document.body.innerHTML = `
       <div>
-        <span>
-          <strong></strong>
-          <strong></strong>
+        <span id="span1">
+          <strong id="strong1">
+            <strong id="nestedStrong1"></strong>
+          </strong>
+          <strong id="strong2">
+            <strong id="nestedStrong2"></strong>
+          </strong>
+          <span id="nestedSpan1">
+            <strong id="nestedStrong3"></strong>
+          </span>
         </span>
-        <span>
-          <strong></strong>
+        <span id="span2">
+          <strong id="strong3">
+            <strong id="nestedStrong4"></strong>
+          </strong>
+          <span id="nestedSpan2"></span>
         </span>
-        <strong></strong>
+        <strong id="strong4">
+          <strong id="nestedStrong5"></strong>        
+        </strong>
       </div>
       <span>
         <strong></strong>
@@ -32,10 +51,20 @@ describe('DOMQuery', () => {
       <strong></strong>
     `;
 
-    root = document.querySelector('div');
-    [span1, span2, strong4] = Array.from(root!.children);
-    [strong1, strong2] = Array.from(span1!.children);
-    [strong3] = Array.from(span2!.children);
+    root = document.querySelector('div')!;
+    span1 = root.querySelector('#span1')!;
+    span2 = root.querySelector('#span2')!;
+    nestedSpan1 = root.querySelector('#nestedSpan1')!;
+    nestedSpan2 = root.querySelector('#nestedSpan2')!;
+    strong1 = root.querySelector('#strong1')!;
+    strong2 = root.querySelector('#strong2')!;
+    strong3 = root.querySelector('#strong3')!;
+    strong4 = root.querySelector('#strong4')!;
+    nestedStrong1 = root.querySelector('#nestedStrong1')!;
+    nestedStrong2 = root.querySelector('#nestedStrong2')!;
+    nestedStrong3 = root.querySelector('#nestedStrong3')!;
+    nestedStrong4 = root.querySelector('#nestedStrong4')!;
+    nestedStrong5 = root.querySelector('#nestedStrong5')!;
 
     rootQuery = new DOMQuery(root);
   });
@@ -61,48 +90,92 @@ describe('DOMQuery', () => {
   test('it only matches in the root', () => {
     expect(rootQuery.createChild('span', null).queryAll()).toEqual([
       span1,
+      nestedSpan1,
       span2,
+      nestedSpan2,
     ]);
     expect(rootQuery.createChild('span', 0).queryAll()).toEqual([span1]);
-    expect(rootQuery.createChild('span', 1).queryAll()).toEqual([span2]);
-    expect(rootQuery.createChild('span', 2).queryAll()).toEqual([]);
+    expect(rootQuery.createChild('span', 1).queryAll()).toEqual([nestedSpan1]);
+    expect(rootQuery.createChild('span', 2).queryAll()).toEqual([span2]);
+    expect(rootQuery.createChild('span', 3).queryAll()).toEqual([nestedSpan2]);
+    expect(rootQuery.createChild('span', 4).queryAll()).toEqual([]);
 
     expect(rootQuery.createChild('strong', null).queryAll()).toEqual([
       strong1,
+      nestedStrong1,
       strong2,
+      nestedStrong2,
+      nestedStrong3,
       strong3,
+      nestedStrong4,
       strong4,
+      nestedStrong5,
     ]);
     expect(rootQuery.createChild('strong', 0).queryAll()).toEqual([strong1]);
-    expect(rootQuery.createChild('strong', 1).queryAll()).toEqual([strong2]);
-    expect(rootQuery.createChild('strong', 2).queryAll()).toEqual([strong3]);
-    expect(rootQuery.createChild('strong', 3).queryAll()).toEqual([strong4]);
-    expect(rootQuery.createChild('strong', 4).queryAll()).toEqual([]);
+    expect(rootQuery.createChild('strong', 1).queryAll()).toEqual([
+      nestedStrong1,
+    ]);
+    expect(rootQuery.createChild('strong', 2).queryAll()).toEqual([strong2]);
+    expect(rootQuery.createChild('strong', 3).queryAll()).toEqual([
+      nestedStrong2,
+    ]);
+    expect(rootQuery.createChild('strong', 4).queryAll()).toEqual([
+      nestedStrong3,
+    ]);
+    expect(rootQuery.createChild('strong', 5).queryAll()).toEqual([strong3]);
+    expect(rootQuery.createChild('strong', 6).queryAll()).toEqual([
+      nestedStrong4,
+    ]);
+    expect(rootQuery.createChild('strong', 7).queryAll()).toEqual([strong4]);
+    expect(rootQuery.createChild('strong', 8).queryAll()).toEqual([
+      nestedStrong5,
+    ]);
+    expect(rootQuery.createChild('strong', 9).queryAll()).toEqual([]);
 
     expect(
       rootQuery.createChild('span', null).createChild('strong', null).queryAll()
-    ).toEqual([strong1, strong2, strong3]);
+    ).toEqual([
+      strong1,
+      nestedStrong1,
+      strong2,
+      nestedStrong2,
+      nestedStrong3,
+      strong3,
+      nestedStrong4,
+    ]);
     expect(
       rootQuery.createChild('span', null).createChild('strong', 0).queryAll()
     ).toEqual([strong1]);
     expect(
       rootQuery.createChild('span', null).createChild('strong', 1).queryAll()
-    ).toEqual([strong2]);
+    ).toEqual([nestedStrong1]);
     expect(
       rootQuery.createChild('span', null).createChild('strong', 2).queryAll()
-    ).toEqual([strong3]);
+    ).toEqual([strong2]);
     expect(
       rootQuery.createChild('span', null).createChild('strong', 3).queryAll()
+    ).toEqual([nestedStrong2]);
+    expect(
+      rootQuery.createChild('span', null).createChild('strong', 4).queryAll()
+    ).toEqual([nestedStrong3]);
+    expect(
+      rootQuery.createChild('span', null).createChild('strong', 5).queryAll()
+    ).toEqual([strong3]);
+    expect(
+      rootQuery.createChild('span', null).createChild('strong', 6).queryAll()
+    ).toEqual([nestedStrong4]);
+    expect(
+      rootQuery.createChild('span', null).createChild('strong', 7).queryAll()
     ).toEqual([]);
 
     expect(
       rootQuery.createChild('span', 0).createChild('strong', null).queryAll()
-    ).toEqual([strong1, strong2]);
-    expect(
-      rootQuery.createChild('span', 1).createChild('strong', null).queryAll()
-    ).toEqual([strong3]);
+    ).toEqual([strong1, nestedStrong1, strong2, nestedStrong2, nestedStrong3]);
     expect(
       rootQuery.createChild('span', 2).createChild('strong', null).queryAll()
+    ).toEqual([strong3, nestedStrong4]);
+    expect(
+      rootQuery.createChild('span', 3).createChild('strong', null).queryAll()
     ).toEqual([]);
   });
 
@@ -136,11 +209,25 @@ describe('DOMQuery', () => {
     let child = rootQuery.createChild('span', null);
     expect(child.selectorArray.toString()).toEqual('span');
     expect(child.query()).toEqual(span1);
-    expect(child.queryAll()).toEqual([span1, span2]);
+    expect(child.queryAll()).toEqual([span1, nestedSpan1, span2, nestedSpan2]);
 
     // selector doesn't match
     child = rootQuery.createChild('section', null);
     expect(child.selectorArray.toString()).toEqual('section');
+    expect(child.query()).toEqual(null);
+    expect(child.queryAll()).toEqual([]);
+  });
+
+  test('root + scoped selector', () => {
+    // selector matches
+    let child = rootQuery.createChild('> span', null);
+    expect(child.selectorArray.toString()).toEqual('> span');
+    expect(child.query()).toEqual(span1);
+    expect(child.queryAll()).toEqual([span1, span2]);
+
+    // selector doesn't match
+    child = rootQuery.createChild('> section', null);
+    expect(child.selectorArray.toString()).toEqual('> section');
     expect(child.query()).toEqual(null);
     expect(child.queryAll()).toEqual([]);
   });
@@ -152,14 +239,14 @@ describe('DOMQuery', () => {
     expect(child.query()).toEqual(span1);
     expect(child.queryAll()).toEqual([span1]);
 
-    child = rootQuery.createChild('span', 1);
-    expect(child.selectorArray.toString()).toEqual('span[1]');
+    child = rootQuery.createChild('span', 2);
+    expect(child.selectorArray.toString()).toEqual('span[2]');
     expect(child.query()).toEqual(span2);
     expect(child.queryAll()).toEqual([span2]);
 
     // index does not match
-    child = rootQuery.createChild('span', 2);
-    expect(child.selectorArray.toString()).toEqual('span[2]');
+    child = rootQuery.createChild('span', 4);
+    expect(child.selectorArray.toString()).toEqual('span[4]');
     expect(child.query()).toEqual(null);
     expect(child.queryAll()).toEqual([]);
 
@@ -175,7 +262,15 @@ describe('DOMQuery', () => {
     let child = rootQuery.createChild('span', null).createChild('strong', null);
     expect(child.selectorArray.toString()).toEqual('span strong');
     expect(child.query()).toEqual(strong1);
-    expect(child.queryAll()).toEqual([strong1, strong2, strong3]);
+    expect(child.queryAll()).toEqual([
+      strong1,
+      nestedStrong1,
+      strong2,
+      nestedStrong2,
+      nestedStrong3,
+      strong3,
+      nestedStrong4,
+    ]);
 
     // child selector doesn't match
     child = rootQuery.createChild('span', null).createChild('section', null);
@@ -190,20 +285,55 @@ describe('DOMQuery', () => {
     expect(child.queryAll()).toEqual([]);
   });
 
+  test('root + selector + scoped selector', () => {
+    // both selectors match
+    let child = rootQuery
+      .createChild('span', null)
+      .createChild('> strong', null);
+    expect(child.selectorArray.toString()).toEqual('span > strong');
+    expect(child.query()).toEqual(strong1);
+    expect(child.queryAll()).toEqual([
+      strong1,
+      strong2,
+      nestedStrong3,
+      strong3,
+    ]);
+
+    // child selector doesn't match
+    child = rootQuery.createChild('span', null).createChild('> section', null);
+    expect(child.selectorArray.toString()).toEqual('span > section');
+    expect(child.query()).toEqual(null);
+    expect(child.queryAll()).toEqual([]);
+
+    // parent selector doesn't match
+    child = rootQuery
+      .createChild('section', null)
+      .createChild('> strong', null);
+    expect(child.selectorArray.toString()).toEqual('section > strong');
+    expect(child.query()).toEqual(null);
+    expect(child.queryAll()).toEqual([]);
+  });
+
   test('root + selector + index + selector', () => {
     // matches
     let child = rootQuery.createChild('span', 0).createChild('strong', null);
     expect(child.selectorArray.toString()).toEqual('span[0] strong');
     expect(child.query()).toEqual(strong1);
-    expect(child.queryAll()).toEqual([strong1, strong2]);
-
-    child = rootQuery.createChild('span', 1).createChild('strong', null);
-    expect(child.selectorArray.toString()).toEqual('span[1] strong');
-    expect(child.query()).toEqual(strong3);
-    expect(child.queryAll()).toEqual([strong3]);
+    expect(child.queryAll()).toEqual([
+      strong1,
+      nestedStrong1,
+      strong2,
+      nestedStrong2,
+      nestedStrong3,
+    ]);
 
     child = rootQuery.createChild('span', 2).createChild('strong', null);
     expect(child.selectorArray.toString()).toEqual('span[2] strong');
+    expect(child.query()).toEqual(strong3);
+    expect(child.queryAll()).toEqual([strong3, nestedStrong4]);
+
+    child = rootQuery.createChild('span', 4).createChild('strong', null);
+    expect(child.selectorArray.toString()).toEqual('span[4] strong');
     expect(child.query()).toEqual(null);
     expect(child.queryAll()).toEqual([]);
 
@@ -214,14 +344,50 @@ describe('DOMQuery', () => {
     expect(child.queryAll()).toEqual([]);
 
     // parent index doesn't match
-    child = rootQuery.createChild('span', 2).createChild('section', null);
-    expect(child.selectorArray.toString()).toEqual('span[2] section');
+    child = rootQuery.createChild('span', 4).createChild('section', null);
+    expect(child.selectorArray.toString()).toEqual('span[4] section');
     expect(child.query()).toEqual(null);
     expect(child.queryAll()).toEqual([]);
 
     // parent selector doesn't match
     child = rootQuery.createChild('section', 0).createChild('strong', null);
     expect(child.selectorArray.toString()).toEqual('section[0] strong');
+    expect(child.query()).toEqual(null);
+    expect(child.queryAll()).toEqual([]);
+  });
+
+  test('root + selector + index + scoped selector', () => {
+    // matches
+    let child = rootQuery.createChild('span', 0).createChild('> strong', null);
+    expect(child.selectorArray.toString()).toEqual('span[0] > strong');
+    expect(child.query()).toEqual(strong1);
+    expect(child.queryAll()).toEqual([strong1, strong2]);
+
+    child = rootQuery.createChild('span', 2).createChild('> strong', null);
+    expect(child.selectorArray.toString()).toEqual('span[2] > strong');
+    expect(child.query()).toEqual(strong3);
+    expect(child.queryAll()).toEqual([strong3]);
+
+    child = rootQuery.createChild('span', 3).createChild('> strong', null);
+    expect(child.selectorArray.toString()).toEqual('span[3] > strong');
+    expect(child.query()).toEqual(null);
+    expect(child.queryAll()).toEqual([]);
+
+    // child selector doesn't match
+    child = rootQuery.createChild('span', 0).createChild('> section', null);
+    expect(child.selectorArray.toString()).toEqual('span[0] > section');
+    expect(child.query()).toEqual(null);
+    expect(child.queryAll()).toEqual([]);
+
+    // parent index doesn't match
+    child = rootQuery.createChild('span', 2).createChild('> section', null);
+    expect(child.selectorArray.toString()).toEqual('span[2] > section');
+    expect(child.query()).toEqual(null);
+    expect(child.queryAll()).toEqual([]);
+
+    // parent selector doesn't match
+    child = rootQuery.createChild('section', 0).createChild('> strong', null);
+    expect(child.selectorArray.toString()).toEqual('section[0] > strong');
     expect(child.query()).toEqual(null);
     expect(child.queryAll()).toEqual([]);
   });
@@ -233,19 +399,19 @@ describe('DOMQuery', () => {
     expect(child.query()).toEqual(strong1);
     expect(child.queryAll()).toEqual([strong1]);
 
-    child = rootQuery.createChild('span', null).createChild('strong', 1);
-    expect(child.selectorArray.toString()).toEqual('span strong[1]');
+    child = rootQuery.createChild('span', null).createChild('strong', 2);
+    expect(child.selectorArray.toString()).toEqual('span strong[2]');
     expect(child.query()).toEqual(strong2);
     expect(child.queryAll()).toEqual([strong2]);
 
-    child = rootQuery.createChild('span', null).createChild('strong', 2);
-    expect(child.selectorArray.toString()).toEqual('span strong[2]');
+    child = rootQuery.createChild('span', null).createChild('strong', 5);
+    expect(child.selectorArray.toString()).toEqual('span strong[5]');
     expect(child.query()).toEqual(strong3);
     expect(child.queryAll()).toEqual([strong3]);
 
     // child index doesn't match
-    child = rootQuery.createChild('span', null).createChild('strong', 3);
-    expect(child.selectorArray.toString()).toEqual('span strong[3]');
+    child = rootQuery.createChild('span', null).createChild('strong', 9);
+    expect(child.selectorArray.toString()).toEqual('span strong[9]');
     expect(child.query()).toEqual(null);
     expect(child.queryAll()).toEqual([]);
 
@@ -269,24 +435,24 @@ describe('DOMQuery', () => {
     expect(child.query()).toEqual(strong1);
     expect(child.queryAll()).toEqual([strong1]);
 
-    child = rootQuery.createChild('span', 0).createChild('strong', 1);
-    expect(child.selectorArray.toString()).toEqual('span[0] strong[1]');
+    child = rootQuery.createChild('span', 0).createChild('strong', 2);
+    expect(child.selectorArray.toString()).toEqual('span[0] strong[2]');
     expect(child.query()).toEqual(strong2);
     expect(child.queryAll()).toEqual([strong2]);
 
-    child = rootQuery.createChild('span', 1).createChild('strong', 0);
-    expect(child.selectorArray.toString()).toEqual('span[1] strong[0]');
+    child = rootQuery.createChild('span', 2).createChild('strong', 0);
+    expect(child.selectorArray.toString()).toEqual('span[2] strong[0]');
     expect(child.query()).toEqual(strong3);
     expect(child.queryAll()).toEqual([strong3]);
 
     // child index doesn't match
-    child = rootQuery.createChild('span', 0).createChild('strong', 2);
-    expect(child.selectorArray.toString()).toEqual('span[0] strong[2]');
+    child = rootQuery.createChild('span', 0).createChild('strong', 5);
+    expect(child.selectorArray.toString()).toEqual('span[0] strong[5]');
     expect(child.query()).toEqual(null);
     expect(child.queryAll()).toEqual([]);
 
-    child = rootQuery.createChild('span', 1).createChild('strong', 1);
-    expect(child.selectorArray.toString()).toEqual('span[1] strong[1]');
+    child = rootQuery.createChild('span', 2).createChild('strong', 2);
+    expect(child.selectorArray.toString()).toEqual('span[2] strong[2]');
     expect(child.query()).toEqual(null);
     expect(child.queryAll()).toEqual([]);
 
@@ -297,8 +463,8 @@ describe('DOMQuery', () => {
     expect(child.queryAll()).toEqual([]);
 
     // parent index doesn't match
-    child = rootQuery.createChild('span', 2).createChild('strong', 0);
-    expect(child.selectorArray.toString()).toEqual('span[2] strong[0]');
+    child = rootQuery.createChild('span', 4).createChild('strong', 0);
+    expect(child.selectorArray.toString()).toEqual('span[4] strong[0]');
     expect(child.query()).toEqual(null);
     expect(child.queryAll()).toEqual([]);
 
@@ -342,8 +508,8 @@ describe('DOMQuery', () => {
     expect(child.query()).toEqual(span1);
     expect(child.queryAll()).toEqual([span1]);
 
-    child = rootQuery.createChild('span', 1).createChild('', 0);
-    expect(child.selectorArray.toString()).toEqual('span[1][0]');
+    child = rootQuery.createChild('span', 2).createChild('', 0);
+    expect(child.selectorArray.toString()).toEqual('span[2][0]');
     expect(child.query()).toEqual(span2);
     expect(child.queryAll()).toEqual([span2]);
 
@@ -354,14 +520,14 @@ describe('DOMQuery', () => {
     expect(child.queryAll()).toEqual([]);
 
     // parent index doesn't match
-    child = rootQuery.createChild('span', 2).createChild('', 0);
-    expect(child.selectorArray.toString()).toEqual('span[2][0]');
+    child = rootQuery.createChild('span', 5).createChild('', 0);
+    expect(child.selectorArray.toString()).toEqual('span[5][0]');
     expect(child.query()).toEqual(null);
     expect(child.queryAll()).toEqual([]);
 
     // parent index doesn't match and child index is non-zero
-    child = rootQuery.createChild('span', 2).createChild('', 1);
-    expect(child.selectorArray.toString()).toEqual('span[2][1]');
+    child = rootQuery.createChild('span', 5).createChild('', 1);
+    expect(child.selectorArray.toString()).toEqual('span[5][1]');
     expect(child.query()).toEqual(null);
     expect(child.queryAll()).toEqual([]);
 
@@ -383,6 +549,32 @@ describe('DOMQuery', () => {
 
     child = rootQuery.createChild('section', 1).createChild('', 1);
     expect(child.selectorArray.toString()).toEqual('section[1][1]');
+    expect(child.query()).toEqual(null);
+    expect(child.queryAll()).toEqual([]);
+  });
+
+  test('root + scoped selector + scoped selector', () => {
+    // matches
+    let child = rootQuery
+      .createChild('> span', null)
+      .createChild('> strong', null);
+    expect(child.selectorArray.toString()).toEqual('> span > strong');
+    expect(child.query()).toEqual(strong1);
+    expect(child.queryAll()).toEqual([strong1, strong2, strong3]);
+
+    // parent selector doesn't match
+    child = rootQuery
+      .createChild('> section', null)
+      .createChild('> strong', null);
+    expect(child.selectorArray.toString()).toEqual('> section > strong');
+    expect(child.query()).toEqual(null);
+    expect(child.queryAll()).toEqual([]);
+
+    // child selector doesn't match
+    child = rootQuery
+      .createChild('> span', null)
+      .createChild('> section', null);
+    expect(child.selectorArray.toString()).toEqual('> span > section');
     expect(child.query()).toEqual(null);
     expect(child.queryAll()).toEqual([]);
   });

--- a/packages/fractal-page-object/src/__tests__/global-selector.ts
+++ b/packages/fractal-page-object/src/__tests__/global-selector.ts
@@ -8,6 +8,7 @@ describe('globalSelector()', () => {
   test('it requires a valid selector and the class must be a PageObject subclass', () => {
     expect(() => globalSelector('')).toThrow();
     expect(() => globalSelector('  ')).toThrow();
+    expect(() => selector('$,')).toThrow();
     // @ts-expect-error violate types to make sure validation throws
     expect(() => globalSelector('', class {})).toThrow();
   });
@@ -119,5 +120,29 @@ describe('globalSelector()', () => {
     expect(page.globalP.elementId).toEqual('p1');
     expect(page.globalP[0].element).toEqual(p);
     expect(page.globalP[0].elementId).toEqual('p1');
+  });
+
+  test('it works with a scoped selector', () => {
+    document.body.innerHTML = `
+      <div>
+        <p><span></span></p>
+        <span></span>
+      </div>
+      <span></span>
+    `;
+    let div = document.body.children[0];
+    let span = div.children[1];
+
+    setRoot(div);
+
+    class Page extends PageObject {
+      span = selector('> span');
+      globalSpan = globalSelector('> span');
+    }
+    let page = new Page('span');
+
+    expect(page.span.element).toEqual(null);
+    expect(page.globalSpan.element).toEqual(span);
+    expect(page.globalSpan[0].element).toEqual(span);
   });
 });

--- a/packages/fractal-page-object/src/__tests__/selector.ts
+++ b/packages/fractal-page-object/src/__tests__/selector.ts
@@ -5,6 +5,7 @@ describe('selector()', () => {
   test('it requires a valid selector and the class must be a PageObject subclass', () => {
     expect(() => selector('')).toThrow();
     expect(() => selector('  ')).toThrow();
+    expect(() => selector('$,')).toThrow();
     // @ts-expect-error violate types to make sure validation throws
     expect(() => selector('div', class {})).toThrow();
   });
@@ -79,5 +80,19 @@ describe('selector()', () => {
 
     expect(page.pane1.form.input.element?.id).toEqual('input1');
     expect(page.pane2.form.input.element?.id).toEqual('input2');
+  });
+
+  test('it works with a scoped selector', () => {
+    document.body.innerHTML = '<div><div></div></div>';
+    let div = document.body.children[0];
+
+    class Page extends PageObject {
+      div = selector('> div');
+    }
+    let page = new Page();
+
+    expect(page.div.length).toEqual(1);
+    expect(page.div.element).toEqual(div);
+    expect(page.div[0].element).toEqual(div);
   });
 });


### PR DESCRIPTION
Support page objects with selectors like `> .foo` that aren't valid CSS selectors, but can be used to construct valid CSS selectors.