### PR TITLE
Fix README code error

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ class CompletePurchasePage extends PageObject {
   purchaseInfo = selector('.purchase-info');
   purchaseButton = selector('.purchase');
 
-  loginModal = selector('.login-modal', {
+  loginModal = selector('.login-modal', class extends PageObject {
     loginForm = selector('.login-form', LoginForm);
   });
 }


### PR DESCRIPTION
The second parameter to selector is meant to be a PageObject class. Previously the docs had a POJO but also used a class field syntax.