### PR TITLE
List addon on Ember Observer

### DIFF
--- a/packages/fractal-page-object/package.json
+++ b/packages/fractal-page-object/package.json
@@ -6,6 +6,7 @@
     "browser",
     "dom",
     "ember",
+    "ember-addon",
     "ember.js",
     "html",
     "testing"


### PR DESCRIPTION
This adds the "ember-addon" keyword to `package.json` so this addon will be
listed on [emberobserver.com.](https://emberobserver.com/)