### PR TITLE
Improve PageObject() documentation

### DIFF
--- a/packages/fractal-page-object/API.md
+++ b/packages/fractal-page-object/API.md
@@ -77,10 +77,11 @@ will match the root element (the body element or whatever was )
 
 ### Parameters
 
-*   `selector` **[string][24]?** the selector to use for this page object's query (optional, default `''`)
-*   `parent`  (for internal use only) (optional, default `null`)
-*   `index`  (for internal use only) (optional, default `null`)
-*   `rootElement`  (for internal use only) (optional, default `null`)
+*   `selector`  the selector to use for this page object's query (optional, default `''`)
+*   `parent`  the element or page object to use as the root of the page
+    object's query, defaulting to the global root element (optional, default `null`)
+*   `index`  an index to narrow the query to an element at a specific index
+    within the query results (optional, default `null`)
 
 ### Examples
 
@@ -93,21 +94,18 @@ class Page extends PageObject {
 
 setRoot(rootElement);
 
-let page = new Page();
-page.list.elements; // rootElement.querySelectorAll('.list')
-```
-
-```javascript
-import { PageObject, selector, setRoot } from 'fractal-page-object';
-
-class Page extends PageObject {
-  list = selector('.list');
-}
-
-setRoot(rootElement);
-
-let page = new Page('.container');
-page.list.elements; // rootElement.querySelectorAll('.container .list')
+// rootElement.querySelectorAll('.list')
+new Page().list.elements;
+// rootElement.querySelectorAll('.container .list')
+new Page('.container').list.elements;
+// rootElement.querySelectorAll('.container')[0].querySelectorAll('.list')
+new Page('.container', null, 0).list.elements;
+// document.body.querySelectorAll('.list');
+new Page('', document.body).list.elements;
+// document.body.querySelectorAll('.container .list');
+new Page('.container', document.body).list.elements;
+// document.body.querySelectorAll('.container')[1].querySelectorAll('.list');
+new Page('.container', document.body, 1).list.elements;
 ```
 
 ### element
@@ -117,14 +115,14 @@ matching this page object's query if this page object does not have an
 index, or the `index`th matching DOM element if it does have an index
 specified.
 
-Type: ([Element][25] | null)
+Type: ([Element][24] | null)
 
 ### elements
 
 This page object's list of matching DOM elements. If this page object has
 an index, this property will always have a length of 0 or 1.
 
-Type: [Array][26]<[Element][25]>
+Type: [Array][25]<[Element][24]>
 
 ## selector
 
@@ -135,7 +133,7 @@ properties and functions.
 
 ### Parameters
 
-*   `selector` **[string][24]** the selector relative to the parent node
+*   `selector` **[string][26]** the selector relative to the parent node
 *   `Class` **[Function][27]<[PageObject][28]>?** optional [PageObject][1] subclass that
     can be used to extend the functionality of this page object
 
@@ -177,7 +175,7 @@ generates.
 ### Parameters
 
 *   `args` **...any** 
-*   `selector` **[string][24]** the selector
+*   `selector` **[string][26]** the selector
 *   `Class` **[Function][27]<[PageObject][28]>** optional [PageObject][1] subclass that
     can be used to extend the functionality of this page object
 
@@ -232,7 +230,7 @@ element is `document.body`.
 
 ### Parameters
 
-*   `element` **([Element][25] | [Function][27])** the root element or a function that will
+*   `element` **([Element][24] | [Function][27])** the root element or a function that will
     return it
 
 ## assertExists
@@ -246,7 +244,7 @@ you can pass on the element to other utilities.
 
 ### Parameters
 
-*   `msg` **[string][24]** a descriptor for what it could mean when the element doesn't exist
+*   `msg` **[string][26]** a descriptor for what it could mean when the element doesn't exist
 *   `pageObject` **[PageObject][28]** the page object
 
 ### Examples
@@ -313,11 +311,11 @@ Utility to get the fully resolved selector path of a [PageObject][1]
 
 [23]: PageObject#map
 
-[24]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[24]: https://developer.mozilla.org/docs/Web/API/Element
 
-[25]: https://developer.mozilla.org/docs/Web/API/Element
+[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[26]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[26]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
 [27]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 

--- a/packages/fractal-page-object/src/page-object.ts
+++ b/packages/fractal-page-object/src/page-object.ts
@@ -56,10 +56,11 @@ import type { PageObjectConstructor } from './-private/types';
  * When creating a top-level {@link PageObject} directly using `new`, its query
  * will match the root element (the body element or whatever was )
  *
- * @param {string} [selector] the selector to use for this page object's query
- * @param parent (for internal use only)
- * @param index (for internal use only)
- * @param rootElement (for internal use only)
+ * @param selector the selector to use for this page object's query
+ * @param parent the element or page object to use as the root of the page
+ * object's query, defaulting to the global root element
+ * @param index an index to narrow the query to an element at a specific index
+ * within the query results
  *
  * @example
  *
@@ -71,21 +72,18 @@ import type { PageObjectConstructor } from './-private/types';
  *
  * setRoot(rootElement);
  *
- * let page = new Page();
- * page.list.elements; // rootElement.querySelectorAll('.list')
- *
- * @example
- *
- * import { PageObject, selector, setRoot } from 'fractal-page-object';
- *
- * class Page extends PageObject {
- *   list = selector('.list');
- * }
- *
- * setRoot(rootElement);
- *
- * let page = new Page('.container');
- * page.list.elements; // rootElement.querySelectorAll('.container .list')
+ * // rootElement.querySelectorAll('.list')
+ * new Page().list.elements;
+ * // rootElement.querySelectorAll('.container .list')
+ * new Page('.container').list.elements;
+ * // rootElement.querySelectorAll('.container')[0].querySelectorAll('.list')
+ * new Page('.container', null, 0).list.elements;
+ * // document.body.querySelectorAll('.list');
+ * new Page('', document.body).list.elements;
+ * // document.body.querySelectorAll('.container .list');
+ * new Page('.container', document.body).list.elements;
+ * // document.body.querySelectorAll('.container')[1].querySelectorAll('.list');
+ * new Page('.container', document.body, 1).list.elements;
  */
 export default class PageObject extends ArrayStub {
   /**
@@ -142,7 +140,7 @@ export default class PageObject extends ArrayStub {
    */
   [CLONE_WITH_INDEX](index: number): PageObject {
     let Class = this.constructor as PageObjectConstructor<PageObject>;
-    return new Class('', this, index, this.rootElement);
+    return new Class('', this, index);
   }
 
   /**
@@ -169,23 +167,19 @@ export default class PageObject extends ArrayStub {
    * object
    * @param index an optional index, making this page object only describe a
    * single element (or none) rather than a list of elements
-   * @param rootElement an optional element that will be used as the root of
-   * this element's query, overriding the parent and/or global root
    *
    * @private
    */
   constructor(
     selector: string,
     parent?: PageObject | Element | null,
-    index?: number | null,
-    rootElement?: Element | null
+    index?: number | null
   );
 
   constructor(
     private selector: string = '',
     private parent: PageObject | Element | null = null,
-    private index: number | null = null,
-    private rootElement: Element | null = null
+    private index: number | null = null
   ) {
     super();
     return createProxy(this);


### PR DESCRIPTION
Include more examples for different ways of constructing PageObjects in the API documentation, including documenting the previously-undocumented parameters and removing an old unused/unneeded one.

Fixes #75 