### PR TITLE
Add html element type to selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,36 @@ page.loadButton.element.click(); // populates the DOM with list items
 thirdImage.element; // non-null
 ```
 
+### typescript
+By adding a type parameter to the `selector` you can have the attributes of that particular element without type casting or type narrowing:
+
+```typescript
+// Page object elements do not have a checked attribute
+// But HTMLInputElement elements do!
+class Page extends PageObject {
+  checkbox = selector<PageObject<HTMLInputElement>>('.checkbox');
+}
+
+const page = new Page();
+
+page.checkbox.element?.checked // this should exist without having to type narrow or cast
+
+```
+
+For earlier versions of fractal page object, be sure to type narrow or cast.
+
+```typescript
+// type narrowing, prefer this over type casting 
+class Page extends PageObject {
+  checkbox = selector('.checkbox');
+}
+const page = new Page();
+
+if (page.checkbox.element instanceOf HTMLInputElement) {
+  page.checkbox.element?.checked // should work now
+} 
+```
+
 ### Extending
 
 Page objects can be extended by adding any functionality to the `PageObject` subclass:
@@ -307,6 +337,7 @@ class LoginPage extends PageObject {
   loginForm = LoginForm.selector;
 }
 ```
+
 
 ### API
 

--- a/packages/fractal-page-object/src/-private/create-proxy.ts
+++ b/packages/fractal-page-object/src/-private/create-proxy.ts
@@ -10,7 +10,9 @@ import { CLONE_WITH_INDEX } from './types';
  *
  * @returns the proxy implementing the page object & array functionality
  */
-export default function createProxy(pageObject: PageObject): PageObject {
+export default function createProxy<K extends Element = Element>(
+  pageObject: PageObject<K>
+): PageObject<K> {
   return new Proxy(pageObject, {
     get(pageObject, prop: string, receiver) {
       if (Reflect.has(pageObject, prop)) {

--- a/packages/fractal-page-object/src/__tests__/selector.ts
+++ b/packages/fractal-page-object/src/__tests__/selector.ts
@@ -95,4 +95,15 @@ describe('selector()', () => {
     expect(page.div.element).toEqual(div);
     expect(page.div[0].element).toEqual(div);
   });
+
+  test('it works with different HTMLElement generic', () => {
+    document.body.innerHTML = '<input type="checkbox" class="checkbox" checked />';
+
+    class Page extends PageObject {
+      checkbox = selector<PageObject<HTMLInputElement>>('.checkbox');
+    }
+    let page = new Page();
+
+    expect(page.checkbox.element.checked).toBeTruthy();
+  })
 });

--- a/packages/fractal-page-object/src/__tests__/selector.ts
+++ b/packages/fractal-page-object/src/__tests__/selector.ts
@@ -97,13 +97,14 @@ describe('selector()', () => {
   });
 
   test('it works with different HTMLElement generic', () => {
-    document.body.innerHTML = '<input type="checkbox" class="checkbox" checked />';
+    document.body.innerHTML =
+      '<input type="checkbox" class="checkbox" checked />';
 
     class Page extends PageObject {
       checkbox = selector<PageObject<HTMLInputElement>>('.checkbox');
     }
     let page = new Page();
 
-    expect(page.checkbox.element.checked).toBeTruthy();
-  })
+    expect(page.checkbox.element?.checked).toBeTruthy();
+  });
 });

--- a/packages/fractal-page-object/src/page-object.ts
+++ b/packages/fractal-page-object/src/page-object.ts
@@ -85,7 +85,7 @@ import type { PageObjectConstructor } from './-private/types';
  * // document.body.querySelectorAll('.container')[1].querySelectorAll('.list');
  * new Page('.container', document.body, 1).list.elements;
  */
-export default class PageObject extends ArrayStub {
+export default class PageObject<K extends Element = Element> extends ArrayStub {
   /**
    * This page object's single matching DOM element -- the first DOM element
    * matching this page object's query if this page object does not have an
@@ -94,8 +94,8 @@ export default class PageObject extends ArrayStub {
    *
    * @type {Element | null}
    */
-  get element(): Element | null {
-    return this[DOM_QUERY].query();
+  get element(): K | null {
+    return this[DOM_QUERY].query() as unknown as K;
   }
 
   /**
@@ -182,6 +182,6 @@ export default class PageObject extends ArrayStub {
     private index: number | null = null
   ) {
     super();
-    return createProxy(this);
+    return createProxy<K>(this);
   }
 }


### PR DESCRIPTION
For issue: https://github.com/bendemboski/fractal-page-object/issues/56

# What changed
- [x] Updated the generic for `PageObject` and `createProxy` so that `get element` can return not just an `Element` but more specific HTML tags like `HTMLInputElement`.
- [x] Updated tests
- [x] Updated docs

## Note
In the issue the suggestion was `selector<HTMLInputElement>` but this would have been a breaking change. By adding that type to the `PageObject`, people can keep using the selector without specifying a specific element type first. 