### PR TITLE
Support Element sub-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A lightweight page object implementation with a focus on simplicity and extensib
   - [Mental Model](#mental-model)
     - [Page objects as lists](#page-objects-as-lists)
   - [Lazy evaluation](#lazy-evaluation)
+  - [Element types (typescript)](#element-types-typescript)
   - [Extending](#extending)
   - [Re-use](#re-use)
   - [API](#api)
@@ -237,6 +238,32 @@ thirdImage.element; // null
 
 page.loadButton.element.click(); // populates the DOM with list items
 thirdImage.element; // non-null
+```
+
+### Element types (typescript)
+
+By default all elements returned from page objects are typed as generic `Element`s. However, if a page object is known to always return elements of a particular `Element` sub-type, that can be encoded in the page object's declaration:
+
+```typescript
+class Page extends PageObject {
+  loadButton = selector<HTMLButtonElement>('.load');  
+  form = selector('form', class extends PageObject<HTMLFormElement> {
+    input = selector<HTMLInputElement>('.form-input');
+  });
+}
+let page = new Page();
+
+// the `disabled` property is present because `page.loadButton.element` is an
+// `HTMLButtonElement`
+page.loadButton.element.disabled = false;
+
+// the `value` property is present because `page.form.input.element` is an
+// `HTMLInputElement`
+page.form.input.value = ;
+
+// the `submit` method is present because `page.form.element` is an
+// `HTMLFormElement`
+page.form.submit();
 ```
 
 ### Extending

--- a/packages/fractal-page-object/API.md
+++ b/packages/fractal-page-object/API.md
@@ -29,7 +29,8 @@ This class implements all the basic page object functionality, and all page
 objects must inherit from it. It can host [selector][6] and
 [globalSelector][9] fields, and will properly instantiate them as nested
 [PageObject][1]s when accessed. Each page object represents a DOM query
-that matches zero or more [Element][19]s.
+that matches zero or more [Element][19]s (or subclasses of [Element][19]
+\-- see [ElementType][20]).
 
 [PageObject][1]s exist in a tree where each [PageObject][1]'s elements
 are descendants of its parent's elements. The root of the tree is a top-level
@@ -60,14 +61,15 @@ they are constructed, but is evaluated and re-evaluated each time a property
 that depends on it is accessed.
 
 [PageObject][1]s expose an API for interacting with their matching
-elements that comprises [PageObject#element][20],
-[PageObject#elements][21], and an [Array][22] API that exposes the page
-object's matching [Element][19]s wrapped in indexed [PageObject][1]s.
-The index operator will return an indexed [PageObject][1] that may or may
-not match an element (similar to how you can index off the end of a native
-array and get `undefined`), while various array iteration methods like
-[PageObject#map][23] generate a range of [PageObject][1]s that reflect
-only the indices that actually match an element.
+elements that comprises [PageObject#element][21],
+[PageObject#elements][22], and an [Array][23] API that exposes the page
+object's matching [ElementType][20]s wrapped in indexed
+[PageObject][1]s. The index operator will return an indexed
+[PageObject][1] that may or may not match an element (similar to how you
+can index off the end of a native array and get `undefined`), while various
+array iteration methods like [PageObject#map][24] generate a range of
+[PageObject][1]s that reflect only the indices that actually match an
+element.
 
 Descendant [PageObject][1]s are defined by subclassing [PageObject][1]
 and using the [selector][6] factory function to initialize class fields.
@@ -115,14 +117,14 @@ matching this page object's query if this page object does not have an
 index, or the `index`th matching DOM element if it does have an index
 specified.
 
-Type: ([Element][24] | null)
+Type: (ElementType | null)
 
 ### elements
 
 This page object's list of matching DOM elements. If this page object has
 an index, this property will always have a length of 0 or 1.
 
-Type: [Array][25]<[Element][24]>
+Type: [Array][23]\<ElementType>
 
 ## selector
 
@@ -133,8 +135,8 @@ properties and functions.
 
 ### Parameters
 
-*   `selector` **[string][26]** the selector relative to the parent node
-*   `Class` **[Function][27]<[PageObject][28]>?** optional [PageObject][1] subclass that
+*   `selector` **[string][25]** the selector relative to the parent node
+*   `Class` **[Function][26]<[PageObject][1]>?** optional [PageObject][1] subclass that
     can be used to extend the functionality of this page object
 
 ### Examples
@@ -152,7 +154,7 @@ page.list.elements; // document.body.querySelectorAll('.list')
 page.list.items.elements; // document.body.querySelectorAll('.list li')
 ```
 
-Returns **[PageObject][28]** a [PageObject][1] or [PageObject][1] subclass
+Returns **[PageObject][1]** a [PageObject][1] or [PageObject][1] subclass
 instance
 
 ## globalSelector
@@ -162,7 +164,7 @@ parent page object. Useful for cases like popovers and dropdowns, where the
 UI control is logically inside a given component, but all or part of it
 renders elsewhere in the DOM, such as directly under the body.
 [globalSelector][9] accepts a selector and optional custom class like
-[selector()][29], but the queries of the page objects it generates will be
+[selector()][27], but the queries of the page objects it generates will be
 executed from the root (`document.body` or whatever was passed to
 [setRoot][12]) rather than the parent page object's elements.
 
@@ -174,9 +176,9 @@ generates.
 
 ### Parameters
 
-*   `args` **...any** 
-*   `selector` **[string][26]** the selector
-*   `Class` **[Function][27]<[PageObject][28]>** optional [PageObject][1] subclass that
+*   `args` **...any**&#x20;
+*   `selector` **[string][25]** the selector
+*   `Class` **[Function][26]<[PageObject][1]>** optional [PageObject][1] subclass that
     can be used to extend the functionality of this page object
 
 ### Examples
@@ -219,7 +221,7 @@ page.listItems[0].popover; // document.body.querySelectorAll('.popover')
 page.listItems[0].popover.icon; // document.body.querySelectorAll('.popover .icon')
 ```
 
-Returns **[PageObject][28]** a [PageObject][1] or [PageObject][1] subclass
+Returns **[PageObject][1]** a [PageObject][1] or [PageObject][1] subclass
 instance
 
 ## setRoot
@@ -230,7 +232,7 @@ element is `document.body`.
 
 ### Parameters
 
-*   `element` **([Element][24] | [Function][27])** the root element or a function that will
+*   `element` **([Element][19] | [Function][26])** the root element or a function that will
     return it
 
 ## assertExists
@@ -244,8 +246,8 @@ you can pass on the element to other utilities.
 
 ### Parameters
 
-*   `msg` **[string][26]** a descriptor for what it could mean when the element doesn't exist
-*   `pageObject` **[PageObject][28]** the page object
+*   `msg` **[string][25]** a descriptor for what it could mean when the element doesn't exist
+*   `pageObject` **[PageObject][1]** the page object
 
 ### Examples
 
@@ -263,7 +265,7 @@ Utility to get the fully resolved selector path of a [PageObject][1]
 
 ### Parameters
 
-*   `pageObject`  
+*   `pageObject` &#x20;
 
 [1]: #pageobject
 
@@ -303,22 +305,18 @@ Utility to get the fully resolved selector path of a [PageObject][1]
 
 [19]: https://developer.mozilla.org/docs/Web/API/Element
 
-[20]: #pageobjectelement
+[20]: ElementType
 
-[21]: #pageobjectelements
+[21]: #pageobjectelement
 
-[22]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[22]: #pageobjectelements
 
-[23]: PageObject#map
+[23]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[24]: https://developer.mozilla.org/docs/Web/API/Element
+[24]: PageObject#map
 
-[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[26]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[26]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[27]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
-
-[28]: #pageobject
-
-[29]: selector\(\)
+[27]: selector\(\)

--- a/packages/fractal-page-object/API.md
+++ b/packages/fractal-page-object/API.md
@@ -131,7 +131,9 @@ Type: [Array][23]\<ElementType>
 Define a child PageObject. It can optionally be supplied with a
 [PageObject][1] subclass definition to allow customizing functionality on
 the page object, such as defining (grand)child page objects, or other helpful
-properties and functions.
+properties and functions. Alternatively, it can be passed an [Element][19]
+subclass as a type argument so elements its page objects produces will be
+typed more specifically.
 
 ### Parameters
 
@@ -152,6 +154,17 @@ class Page extends PageObject {
 let page = new Page();
 page.list.elements; // document.body.querySelectorAll('.list')
 page.list.items.elements; // document.body.querySelectorAll('.list li')
+```
+
+```javascript
+import { PageObject, selector } from 'fractal-page-object';
+
+class Page extends PageObject {
+  input = selector<HTMLInputElement>('input');
+}
+let page = new Page();
+page.input.element; // type is HTMLInputElement
+page.input.element.value; // no type cast needed
 ```
 
 Returns **[PageObject][1]** a [PageObject][1] or [PageObject][1] subclass
@@ -178,6 +191,8 @@ generates.
 
 *   `args` **...any**&#x20;
 *   `selector` **[string][25]** the selector
+*   `rootElement` **[Element][19]** optional the root element under which to query
+    the selector.
 *   `Class` **[Function][26]<[PageObject][1]>** optional [PageObject][1] subclass that
     can be used to extend the functionality of this page object
 
@@ -219,6 +234,17 @@ let page = new Page();
 page.listItems[0]; // testContainer.querySelectorAll('.listItems')[0]
 page.listItems[0].popover; // document.body.querySelectorAll('.popover')
 page.listItems[0].popover.icon; // document.body.querySelectorAll('.popover .icon')
+```
+
+```javascript
+import { PageObject, globalSelector } from 'fractal-page-object';
+
+class Page extends PageObject {
+  input = globalSelector<HTMLInputElement>('input');
+}
+let page = new Page();
+page.input.element; // type is HTMLInputElement
+page.input.element.value; // no type cast needed
 ```
 
 Returns **[PageObject][1]** a [PageObject][1] or [PageObject][1] subclass

--- a/packages/fractal-page-object/src/-private/array-stub.ts
+++ b/packages/fractal-page-object/src/-private/array-stub.ts
@@ -10,11 +10,11 @@ import type { WithElement } from './types';
  *
  * It really seems like there should be a better way to do this, but I can't
  * figure out how else to make PageObject subclasses look like arrays of
- * `WithElement<this>`.
+ * `WithElement<this, ElementType>`.
  *
  * @private
  */
-export default class ArrayStub {
+export default class ArrayStub<ElementType extends Element> {
   //
   // Array API
   //
@@ -25,7 +25,7 @@ export default class ArrayStub {
   //
   // It really seems like there should be a better way to do this, but I can't
   // figure out how else to make PageObject subclasses look like arrays of
-  // `WithElement<this>`.
+  // `WithElement<this, ElementType>`.
   //
 
   /**
@@ -35,46 +35,58 @@ export default class ArrayStub {
   /**
    * @private
    */
-  declare pop: () => WithElement<this> | undefined;
+  declare pop: () => WithElement<this, ElementType> | undefined;
   /**
    * @private
    */
   declare concat: (
     ...items:
-      | ConcatArray<WithElement<this>>[]
-      | (WithElement<this> | ConcatArray<WithElement<this>>)[]
-      | (WithElement<this> | ConcatArray<WithElement<this>>)[]
-  ) => WithElement<this>[];
+      | ConcatArray<WithElement<this, ElementType>>[]
+      | (
+          | WithElement<this, ElementType>
+          | ConcatArray<WithElement<this, ElementType>>
+        )[]
+      | (
+          | WithElement<this, ElementType>
+          | ConcatArray<WithElement<this, ElementType>>
+        )[]
+  ) => WithElement<this, ElementType>[];
   /**
    * @private
    */
-  declare reverse: () => WithElement<this>[];
+  declare reverse: () => WithElement<this, ElementType>[];
   /**
    * @private
    */
-  declare shift: () => WithElement<this> | undefined;
+  declare shift: () => WithElement<this, ElementType> | undefined;
   /**
    * @private
    */
-  declare slice: (_start?: number, _end?: number) => WithElement<this>[];
+  declare slice: (
+    _start?: number,
+    _end?: number
+  ) => WithElement<this, ElementType>[];
   /**
    * @private
    */
   declare sort: (
-    _compareFn?: (a: WithElement<this>, b: WithElement<this>) => number
+    _compareFn?: (
+      a: WithElement<this, ElementType>,
+      b: WithElement<this, ElementType>
+    ) => number
   ) => this[];
   /**
    * @private
    */
   declare indexOf: (
-    _searchElement: WithElement<this>,
+    _searchElement: WithElement<this, ElementType>,
     _fromIndex?: number
   ) => number;
   /**
    * @private
    */
   declare lastIndexOf: (
-    _searchElement: WithElement<this>,
+    _searchElement: WithElement<this, ElementType>,
     _fromIndex?: number
   ) => number;
   /**
@@ -82,9 +94,9 @@ export default class ArrayStub {
    */
   declare every: (
     predicate: (
-      value: WithElement<this>,
+      value: WithElement<this, ElementType>,
       index: number,
-      array: WithElement<this>[]
+      array: WithElement<this, ElementType>[]
     ) => unknown,
     _thisArg?: any
   ) => boolean;
@@ -93,9 +105,9 @@ export default class ArrayStub {
    */
   declare some: (
     _predicate: (
-      value: WithElement<this>,
+      value: WithElement<this, ElementType>,
       index: number,
-      array: WithElement<this>[]
+      array: WithElement<this, ElementType>[]
     ) => unknown,
     _thisArg?: any
   ) => boolean;
@@ -104,9 +116,9 @@ export default class ArrayStub {
    */
   declare forEach: (
     _callbackfn: (
-      value: WithElement<this>,
+      value: WithElement<this, ElementType>,
       index: number,
-      array: WithElement<this>[]
+      array: WithElement<this, ElementType>[]
     ) => void,
     _thisArg?: any
   ) => void;
@@ -115,9 +127,9 @@ export default class ArrayStub {
    */
   declare map: <U>(
     _callbackfn: (
-      value: WithElement<this>,
+      value: WithElement<this, ElementType>,
       index: number,
-      array: WithElement<this>[]
+      array: WithElement<this, ElementType>[]
     ) => U,
     _thisArg?: any
   ) => U[];
@@ -126,21 +138,21 @@ export default class ArrayStub {
    */
   declare filter: (
     predicate: (
-      value: WithElement<this>,
+      value: WithElement<this, ElementType>,
       index: number,
-      array: WithElement<this>[]
+      array: WithElement<this, ElementType>[]
     ) => unknown,
     thisArg?: any
-  ) => WithElement<this>[];
+  ) => WithElement<this, ElementType>[];
   /**
    * @private
    */
   declare reduce: <U>(
     _callbackfn: (
       previousValue: U,
-      currentValue: WithElement<this>,
+      currentValue: WithElement<this, ElementType>,
       currentIndex: number,
-      array: WithElement<this>[]
+      array: WithElement<this, ElementType>[]
     ) => U,
     initialValue: U
   ) => U;
@@ -150,9 +162,9 @@ export default class ArrayStub {
   declare reduceRight: <U>(
     _callbackfn: (
       previousValue: U,
-      currentValue: WithElement<this>,
+      currentValue: WithElement<this, ElementType>,
       currentIndex: number,
-      array: WithElement<this>[]
+      array: WithElement<this, ElementType>[]
     ) => U,
     initialValue: U
   ) => U;
@@ -161,20 +173,20 @@ export default class ArrayStub {
    */
   declare find: (
     predicate: (
-      value: WithElement<this>,
+      value: WithElement<this, ElementType>,
       index: number,
-      obj: WithElement<this>[]
+      obj: WithElement<this, ElementType>[]
     ) => unknown,
     thisArg?: any
-  ) => WithElement<this> | undefined;
+  ) => WithElement<this, ElementType> | undefined;
   /**
    * @private
    */
   declare findIndex: (
     _predicate: (
-      value: WithElement<this>,
+      value: WithElement<this, ElementType>,
       index: number,
-      obj: WithElement<this>[]
+      obj: WithElement<this, ElementType>[]
     ) => unknown,
     _thisArg?: any
   ) => number;
@@ -182,17 +194,21 @@ export default class ArrayStub {
    * @private
    */
   declare includes: (
-    _searchElement: WithElement<this>,
+    _searchElement: WithElement<this, ElementType>,
     _fromIndex?: number
   ) => boolean;
   /**
    * @private
    */
-  declare [Symbol.iterator]: () => IterableIterator<WithElement<this>>;
+  declare [Symbol.iterator]: () => IterableIterator<
+    WithElement<this, ElementType>
+  >;
   /**
    * @private
    */
-  declare entries: () => IterableIterator<[number, WithElement<this>]>;
+  declare entries: () => IterableIterator<
+    [number, WithElement<this, ElementType>]
+  >;
   /**
    * @private
    */
@@ -200,7 +216,7 @@ export default class ArrayStub {
   /**
    * @private
    */
-  declare values: () => IterableIterator<WithElement<this>>;
+  declare values: () => IterableIterator<WithElement<this, ElementType>>;
 
   /**
    * @private

--- a/packages/fractal-page-object/src/-private/create-proxy.ts
+++ b/packages/fractal-page-object/src/-private/create-proxy.ts
@@ -10,7 +10,9 @@ import { CLONE_WITH_INDEX } from './types';
  *
  * @returns the proxy implementing the page object & array functionality
  */
-export default function createProxy(pageObject: PageObject): PageObject {
+export default function createProxy<ElementType extends Element>(
+  pageObject: PageObject<ElementType>
+): PageObject<ElementType> {
   return new Proxy(pageObject, {
     get(pageObject, prop: string, receiver) {
       if (Reflect.has(pageObject, prop)) {
@@ -69,8 +71,8 @@ export default function createProxy(pageObject: PageObject): PageObject {
  * {@link PageObject} if the actual property value is a
  * {@link PageObjectFactory}
  */
-function getWithFactorySupport(
-  pageObject: PageObject,
+function getWithFactorySupport<ElementType extends Element>(
+  pageObject: PageObject<ElementType>,
   prop: string,
   receiver: unknown
 ) {

--- a/packages/fractal-page-object/src/-private/factory.ts
+++ b/packages/fractal-page-object/src/-private/factory.ts
@@ -7,7 +7,10 @@ import PageObject from '../page-object';
  * The {@link PageObjectFactor#create} method instantiates page objects using
  * the data provided to the factoryt.
  */
-export default class PageObjectFactory<T extends PageObject> {
+export default class PageObjectFactory<
+  ElementType extends Element,
+  T extends PageObject<ElementType>
+> {
   /**
    * @param selector the selector for page objects created from this factory
    * @param Class the class to use when creating page objects. It must be a
@@ -16,7 +19,7 @@ export default class PageObjectFactory<T extends PageObject> {
    */
   constructor(
     private selector: string,
-    private Class?: PageObjectConstructor<T>
+    private Class?: PageObjectConstructor<ElementType, T>
   ) {}
 
   /**
@@ -25,8 +28,13 @@ export default class PageObjectFactory<T extends PageObject> {
    * @param parent the {@link PageObject} to set as the new page object's parent
    * @returns the new page object
    */
-  create(parent?: PageObject | Element): PageObject {
-    let Class = this.Class || (PageObject as PageObjectConstructor<PageObject>);
+  create(parent?: PageObject | Element): PageObject<ElementType> {
+    let Class =
+      this.Class ||
+      (PageObject as PageObjectConstructor<
+        ElementType,
+        PageObject<ElementType>
+      >);
     return new Class(this.selector, parent);
   }
 }

--- a/packages/fractal-page-object/src/-private/global-factory.ts
+++ b/packages/fractal-page-object/src/-private/global-factory.ts
@@ -9,8 +9,9 @@ import Factory from './factory';
  * default to the global root set via {@link setRoot}.
  */
 export default class GlobalPageObjectFactory<
-  T extends PageObject
-> extends Factory<T> {
+  ElementType extends Element,
+  T extends PageObject<ElementType>
+> extends Factory<ElementType, T> {
   /**
    * @param selector the selector for page objects created from this factory
    * @param rootElement the element that will be used to scope the page object's
@@ -21,8 +22,8 @@ export default class GlobalPageObjectFactory<
    */
   constructor(
     selector: string,
-    private rootElement?: Element,
-    Class?: PageObjectConstructor<T>
+    private rootElement?: ElementType,
+    Class?: PageObjectConstructor<ElementType, T>
   ) {
     super(selector, Class);
   }
@@ -33,7 +34,7 @@ export default class GlobalPageObjectFactory<
    * @param parent the {@link PageObject} to set as the new page object's parent
    * @returns the new page object
    */
-  create(): PageObject {
+  create(): PageObject<ElementType> {
     return super.create(this.rootElement);
   }
 }

--- a/packages/fractal-page-object/src/-private/helpers.ts
+++ b/packages/fractal-page-object/src/-private/helpers.ts
@@ -1,9 +1,10 @@
 import PageObject from '../page-object';
 import type { PageObjectConstructor } from './types';
 
-function isPageObjectSubclass<T extends PageObject>(
-  Class: PageObjectConstructor<T>
-) {
+function isPageObjectSubclass<
+  ElementType extends Element,
+  T extends PageObject<ElementType>
+>(Class: PageObjectConstructor<ElementType, T>) {
   return Class === PageObject || Class.prototype instanceof PageObject;
 }
 
@@ -21,10 +22,10 @@ export function safeSelector(selector: string): string {
   return `:scope ${selector}`;
 }
 
-export function validateSelectorArguments<T extends PageObject>(
-  selector: string,
-  Class?: PageObjectConstructor<T>
-): void {
+export function validateSelectorArguments<
+  ElementType extends Element,
+  T extends PageObject<ElementType>
+>(selector: string, Class?: PageObjectConstructor<ElementType, T>): void {
   if (!selector.trim()) {
     throw new Error('Cannot specify an empty selector');
   }

--- a/packages/fractal-page-object/src/-private/helpers.ts
+++ b/packages/fractal-page-object/src/-private/helpers.ts
@@ -5,7 +5,9 @@ function isPageObjectSubclass<
   ElementType extends Element,
   T extends PageObject<ElementType>
 >(Class: PageObjectConstructor<ElementType, T>) {
-  return Class === PageObject || Class.prototype instanceof PageObject;
+  return (
+    (Class as unknown) === PageObject || Class.prototype instanceof PageObject
+  );
 }
 
 /**

--- a/packages/fractal-page-object/src/-private/types.ts
+++ b/packages/fractal-page-object/src/-private/types.ts
@@ -6,13 +6,18 @@ export const CLONE_WITH_INDEX = Symbol('withIndex');
 /**
  * A constructor for a {@link PageObject} or {@link PageObject} subclass
  */
-export type PageObjectConstructor<T extends PageObject> = new (
-  ...args: ConstructorParameters<typeof PageObject>
-) => T | PageObject;
+export type PageObjectConstructor<
+  ElementType extends Element,
+  T extends PageObject<ElementType>
+> = new (...args: ConstructorParameters<typeof PageObject<ElementType>>) =>
+  | T
+  | PageObject<ElementType>;
 
 /**
  * Helper type for a {@link PageObject}s and subclasses that are known to match an element
  *
  * @see {@link ArrayStub#map} etc.
  */
-export type WithElement<T> = T & { element: Element };
+export type WithElement<T, ElementType extends Element> = T & {
+  element: ElementType;
+};

--- a/packages/fractal-page-object/src/-private/types.ts
+++ b/packages/fractal-page-object/src/-private/types.ts
@@ -9,9 +9,7 @@ export const CLONE_WITH_INDEX = Symbol('withIndex');
 export type PageObjectConstructor<
   ElementType extends Element,
   T extends PageObject<ElementType>
-> = new (...args: ConstructorParameters<typeof PageObject<ElementType>>) =>
-  | T
-  | PageObject<ElementType>;
+> = new (...args: ConstructorParameters<typeof PageObject<ElementType>>) => T;
 
 /**
  * Helper type for a {@link PageObject}s and subclasses that are known to match an element

--- a/packages/fractal-page-object/src/__tests__/global-selector.ts
+++ b/packages/fractal-page-object/src/__tests__/global-selector.ts
@@ -145,4 +145,40 @@ describe('globalSelector()', () => {
     expect(page.globalSpan.element).toEqual(span);
     expect(page.globalSpan[0].element).toEqual(span);
   });
+
+  test('it works with an Element sub-type', () => {
+    document.body.innerHTML = `
+      <input value="value1">
+    `;
+
+    class Page extends PageObject {
+      input = globalSelector<HTMLInputElement>('input');
+    }
+    let page = new Page();
+
+    expect(page.input.element?.value).toEqual('value1');
+    expect(page.input.elements[0].value).toEqual('value1');
+  });
+
+  test('it works with a PageObject sub-class with an Element sub-type', () => {
+    document.body.innerHTML = `
+      <input value="value1">
+    `;
+
+    class Page extends PageObject {
+      input = globalSelector(
+        'input',
+        class extends PageObject<HTMLInputElement> {
+          get value() {
+            return this.element?.value;
+          }
+        }
+      );
+    }
+    let page = new Page('span');
+
+    expect(page.input.element?.value).toEqual('value1');
+    expect(page.input.elements[0].value).toEqual('value1');
+    expect(page.input.value).toEqual('value1');
+  });
 });

--- a/packages/fractal-page-object/src/__tests__/global-selector.ts
+++ b/packages/fractal-page-object/src/__tests__/global-selector.ts
@@ -181,4 +181,185 @@ describe('globalSelector()', () => {
     expect(page.input.elements[0].value).toEqual('value1');
     expect(page.input.value).toEqual('value1');
   });
+
+  describe('types', () => {
+    class CustomPageObject extends PageObject {
+      prop1 = 'value1';
+    }
+    class CustomPageObjectCustomElement extends PageObject<HTMLInputElement> {
+      prop2 = 'value2';
+    }
+
+    test('without root element', () => {
+      class Page extends PageObject {
+        /**
+         * Expected cases
+         */
+
+        // All defaults -- `PageObject` producing `Element`s
+        a = globalSelector('.foo');
+        // Customize elements -- `PageObject` producing `HTMLInputElement`s
+        b = globalSelector<HTMLInputElement>('.foo');
+        // Customize page object -- `CustomPageObject` producing `Element`s
+        c = globalSelector('.foo', CustomPageObject);
+        // Customize page object and elements -- `CustomPageObjectCustomElement`
+        // producing `HTMLInputElement`s
+        d = globalSelector('.foo', CustomPageObjectCustomElement);
+
+        /**
+         * Valid, but not recommended cases
+         */
+
+        // Unnecessarily specify the default element type arguments
+        e = globalSelector<Element>('.foo');
+        // Unnecessarily specify the default element and default page object type
+        // arguments
+        g = globalSelector<Element, PageObject>('.foo', PageObject);
+        // Unnecessarily specify the default element and custom page object type
+        // arguments
+        h = globalSelector<Element, CustomPageObject>('.foo', CustomPageObject);
+        // Unnecessarily specify the custom element and custom page object type
+        // arguments
+        i = globalSelector<HTMLInputElement, CustomPageObjectCustomElement>(
+          '.foo',
+          CustomPageObjectCustomElement
+        );
+        // Specify an element type argument that is different from, but cast-able
+        // to, the page object's element type
+        j = globalSelector<Element, CustomPageObjectCustomElement>(
+          '.foo',
+          CustomPageObjectCustomElement
+        );
+        // Specify a custom page object type whose element type is different from,
+        // but cast-able to, the element type argument
+        k = globalSelector<Element, PageObject>('.foo', CustomPageObject);
+
+        /**
+         * Error cases
+         */
+
+        l = globalSelector<Element>(
+          '.foo',
+          // @ts-expect-error cannot specify element type argument when passing a
+          // custom page object function argument because the page object function
+          // argument's type already includes the element type
+          CustomPageObject
+        );
+        // @ts-expect-error cannot specify a page object type argument without
+        // passing the page object class as a function argument
+        m = globalSelector<Element, CustomPageObject>('.foo');
+        n = globalSelector<Element, CustomPageObject>(
+          '.foo',
+          // @ts-expect-error cannot pass a class function argument whose type is
+          // incompatible with the page object type argument
+          PageObject
+        );
+
+        o = globalSelector<
+          HTMLInputElement,
+          // @ts-expect-error cannot specify a page object type whose element type
+          // is not cast-able to the element type argument
+          CustomPageObject
+        >('.foo', CustomPageObject);
+      }
+
+      expect(new Page()).toBeTruthy();
+    });
+
+    test('with root element', () => {
+      class Page extends PageObject {
+        /**
+         * Expected cases
+         */
+
+        // All defaults -- `PageObject` producing `Element`s
+        a = globalSelector('.foo', document.body);
+        // Customize elements -- `PageObject` producing `HTMLInputElement`s
+        b = globalSelector<HTMLInputElement>('.foo', document.body);
+        // Customize page object -- `CustomPageObject` producing `Element`s
+        c = globalSelector('.foo', document.body, CustomPageObject);
+        // Customize page object and elements -- `CustomPageObjectCustomElement`
+        // producing `HTMLInputElement`s
+        d = globalSelector(
+          '.foo',
+          document.body,
+          CustomPageObjectCustomElement
+        );
+
+        /**
+         * Valid, but not recommended cases
+         */
+
+        // Unnecessarily specify the default element type arguments
+        e = globalSelector<Element>('.foo', document.body);
+        // Unnecessarily specify the default element and default page object type
+        // arguments
+        g = globalSelector<Element, PageObject>(
+          '.foo',
+          document.body,
+          PageObject
+        );
+        // Unnecessarily specify the default element and custom page object type
+        // arguments
+        h = globalSelector<Element, CustomPageObject>(
+          '.foo',
+          document.body,
+          CustomPageObject
+        );
+        // Unnecessarily specify the custom element and custom page object type
+        // arguments
+        i = globalSelector<HTMLInputElement, CustomPageObjectCustomElement>(
+          '.foo',
+          document.body,
+          CustomPageObjectCustomElement
+        );
+        // Specify an element type argument that is different from, but cast-able
+        // to, the page object's element type
+        j = globalSelector<Element, CustomPageObjectCustomElement>(
+          '.foo',
+          document.body,
+          CustomPageObjectCustomElement
+        );
+        // Specify a custom page object type whose element type is different from,
+        // but cast-able to, the element type argument
+        k = globalSelector<Element, PageObject>(
+          '.foo',
+          document.body,
+          CustomPageObject
+        );
+
+        /**
+         * Error cases
+         */
+
+        l = globalSelector<Element>(
+          '.foo',
+          document.body,
+          // @ts-expect-error cannot specify element type argument when passing a
+          // custom page object function argument because the page object function
+          // argument's type already includes the element type
+          CustomPageObject
+        );
+        // @ts-expect-error cannot specify a page object type argument without
+        // passing the page object class as a function argument
+        m = globalSelector<Element, CustomPageObject>('.foo', document.body);
+        n = globalSelector<Element, CustomPageObject>(
+          '.foo',
+          document.body,
+          // @ts-expect-error cannot pass a class function argument whose type is
+          // incompatible with the page object type argument
+          PageObject
+        );
+
+        o = globalSelector<
+          HTMLInputElement,
+          // @ts-expect-error cannot specify a page object type whose element type
+          // is not cast-able to the element type argument
+          CustomPageObject
+        >('.foo', document.body, CustomPageObject);
+      }
+
+      expect(new Page()).toBeTruthy();
+    });
+  });
 });

--- a/packages/fractal-page-object/src/__tests__/page-object.ts
+++ b/packages/fractal-page-object/src/__tests__/page-object.ts
@@ -664,5 +664,46 @@ describe('PageObject', () => {
 
       expect(page2.map((o) => o.element.id)).toEqual(['div1']);
     });
+
+    test('the element type can be specified', () => {
+      document.body.innerHTML = `
+        <input value="value1">
+        <input value="value2">
+      `;
+
+      let page = new PageObject<HTMLInputElement>('input');
+
+      expect(page.element?.value).toEqual('value1');
+      expect(page.elements[0].value).toEqual('value1');
+      expect(page.elements[1].value).toEqual('value2');
+      expect(page.elements.map((el) => el.value)).toEqual(['value1', 'value2']);
+    });
+
+    test('the element type applies to subclasses', () => {
+      document.body.innerHTML = `
+        <input value="value1">
+        <input value="value2">
+      `;
+      class Page extends PageObject<HTMLInputElement> {
+        getFn() {
+          return `getFn ${this.element?.value}:[${this.elements
+            .map((e) => e.value)
+            .join(',')}]`;
+        }
+        get getter() {
+          return `getter ${this.element?.value}:[${this.elements
+            .map((e) => e.value)
+            .join(',')}]`;
+        }
+      }
+      let page = new Page('input');
+
+      expect(page.element?.value).toEqual('value1');
+      expect(page.elements[0]?.value).toEqual('value1');
+      expect(page.elements[1]?.value).toEqual('value2');
+      expect(page.elements.map((el) => el.value)).toEqual(['value1', 'value2']);
+      expect(page.getFn()).toEqual('getFn value1:[value1,value2]');
+      expect(page.getter).toEqual('getter value1:[value1,value2]');
+    });
   });
 });

--- a/packages/fractal-page-object/src/__tests__/selector.ts
+++ b/packages/fractal-page-object/src/__tests__/selector.ts
@@ -95,4 +95,36 @@ describe('selector()', () => {
     expect(page.div.element).toEqual(div);
     expect(page.div[0].element).toEqual(div);
   });
+
+  test('it works with an Element sub-type', () => {
+    document.body.innerHTML = '<input value="value1">';
+
+    class Page extends PageObject {
+      input = selector<HTMLInputElement>('input');
+    }
+    let page = new Page();
+
+    expect(page.input.element?.value).toEqual('value1');
+    expect(page.input.elements[0].value).toEqual('value1');
+  });
+
+  test('it works with a PageObject sub-class with an Element sub-type', () => {
+    document.body.innerHTML = '<input value="value1">';
+
+    class Page extends PageObject {
+      input = selector(
+        'input',
+        class extends PageObject<HTMLInputElement> {
+          get value() {
+            return this.element?.value;
+          }
+        }
+      );
+    }
+    let page = new Page();
+
+    expect(page.input.element?.value).toEqual('value1');
+    expect(page.input.elements[0].value).toEqual('value1');
+    expect(page.input.value).toEqual('value1');
+  });
 });

--- a/packages/fractal-page-object/src/__tests__/selector.ts
+++ b/packages/fractal-page-object/src/__tests__/selector.ts
@@ -127,4 +127,87 @@ describe('selector()', () => {
     expect(page.input.elements[0].value).toEqual('value1');
     expect(page.input.value).toEqual('value1');
   });
+
+  test('types', () => {
+    class CustomPageObject extends PageObject {
+      prop1 = 'value1';
+    }
+    class CustomPageObjectCustomElement extends PageObject<HTMLInputElement> {
+      prop2 = 'value2';
+    }
+
+    class Page extends PageObject {
+      /**
+       * Expected cases
+       */
+
+      // All defaults -- `PageObject` producing `Element`s
+      a = selector('.foo');
+      // Customize elements -- `PageObject` producing `HTMLInputElement`s
+      b = selector<HTMLInputElement>('.foo');
+      // Customize page object -- `CustomPageObject` producing `Element`s
+      c = selector('.foo', CustomPageObject);
+      // Customize page object and elements -- `CustomPageObjectCustomElement`
+      // producing `HTMLInputElement`s
+      d = selector('.foo', CustomPageObjectCustomElement);
+
+      /**
+       * Valid, but not recommended cases
+       */
+
+      // Unnecessarily specify the default element type arguments
+      e = selector<Element>('.foo');
+      // Unnecessarily specify the default element and default page object type
+      // arguments
+      g = selector<Element, PageObject>('.foo', PageObject);
+      // Unnecessarily specify the default element and custom page object type
+      // arguments
+      h = selector<Element, CustomPageObject>('.foo', CustomPageObject);
+      // Unnecessarily specify the custom element and custom page object type
+      // arguments
+      i = selector<HTMLInputElement, CustomPageObjectCustomElement>(
+        '.foo',
+        CustomPageObjectCustomElement
+      );
+      // Specify an element type argument that is different from, but cast-able
+      // to, the page object's element type
+      j = selector<Element, CustomPageObjectCustomElement>(
+        '.foo',
+        CustomPageObjectCustomElement
+      );
+      // Specify a custom page object type whose element type is different from,
+      // but cast-able to, the element type argument
+      k = selector<Element, PageObject>('.foo', CustomPageObject);
+
+      /**
+       * Error cases
+       */
+
+      l = selector<Element>(
+        '.foo',
+        // @ts-expect-error cannot specify element type argument when passing a
+        // custom page object function argument because the page object function
+        // argument's type already includes the element type
+        CustomPageObject
+      );
+      // @ts-expect-error cannot specify a page object type argument without
+      // passing the page object class as a function argument
+      m = selector<Element, CustomPageObject>('.foo');
+      n = selector<Element, CustomPageObject>(
+        '.foo',
+        // @ts-expect-error cannot pass a class function argument whose type is
+        // incompatible with the page object type argument
+        PageObject
+      );
+
+      o = selector<
+        HTMLInputElement,
+        // @ts-expect-error cannot specify a page object type whose element type
+        // is not cast-able to the element type argument
+        CustomPageObject
+      >('.foo', CustomPageObject);
+    }
+
+    expect(new Page()).toBeTruthy();
+  });
 });

--- a/packages/fractal-page-object/src/global-selector.ts
+++ b/packages/fractal-page-object/src/global-selector.ts
@@ -3,12 +3,14 @@ import PageObject from './page-object';
 import type { PageObjectConstructor } from './-private/types';
 import { validateSelectorArguments } from './-private/helpers';
 
-type Arguments<T extends PageObject> = [string, PageObjectConstructor<T>?];
-type ArgumentsWithRoot<T extends PageObject> = [
-  string,
-  Element,
-  PageObjectConstructor<T>?
-];
+type Arguments<
+  ElementType extends Element,
+  T extends PageObject<ElementType>
+> = [string, PageObjectConstructor<ElementType, T>?];
+type ArgumentsWithRoot<
+  ElementType extends Element,
+  T extends PageObject<ElementType>
+> = [string, Element, PageObjectConstructor<ElementType, T>?];
 
 /**
  * Define a {@link PageObject} with a global scope, i.e. not scoped by its
@@ -33,10 +35,10 @@ type ArgumentsWithRoot<T extends PageObject> = [
  * @returns {PageObject} a {@link PageObject} or {@link PageObject} subclass
  * instance
  */
-export default function globalSelector<T extends PageObject>(
-  selector: string,
-  Class?: PageObjectConstructor<T>
-): T;
+export default function globalSelector<
+  ElementType extends Element = Element,
+  T extends PageObject<ElementType> = PageObject<ElementType>
+>(selector: string, Class?: PageObjectConstructor<ElementType, T>): T;
 
 /**
  * Define a {@link PageObject} with a global scope, i.e. not scoped by its
@@ -63,10 +65,13 @@ export default function globalSelector<T extends PageObject>(
  * @returns {PageObject} a {@link PageObject} or {@link PageObject} subclass
  * instance
  */
-export default function globalSelector<T extends PageObject>(
+export default function globalSelector<
+  ElementType extends Element = Element,
+  T extends PageObject<ElementType> = PageObject<ElementType>
+>(
   selector: string,
-  rootElement: Element,
-  Class?: PageObjectConstructor<T>
+  rootElement: ElementType,
+  Class?: PageObjectConstructor<ElementType, T>
 ): T;
 
 /**
@@ -130,9 +135,10 @@ export default function globalSelector<T extends PageObject>(
  * page.listItems[0].popover; // document.body.querySelectorAll('.popover')
  * page.listItems[0].popover.icon; // document.body.querySelectorAll('.popover .icon')
  */
-export default function globalSelector<T extends PageObject>(
-  ...args: Arguments<T> | ArgumentsWithRoot<T>
-): T {
+export default function globalSelector<
+  ElementType extends Element = Element,
+  T extends PageObject<ElementType> = PageObject<ElementType>
+>(...args: Arguments<ElementType, T> | ArgumentsWithRoot<ElementType, T>): T {
   let selector = args[0];
   let rootElement;
   let Class;

--- a/packages/fractal-page-object/src/selector.ts
+++ b/packages/fractal-page-object/src/selector.ts
@@ -7,7 +7,44 @@ import { validateSelectorArguments } from './-private/helpers';
  * Define a child PageObject. It can optionally be supplied with a
  * {@link PageObject} subclass definition to allow customizing functionality on
  * the page object, such as defining (grand)child page objects, or other helpful
- * properties and functions.
+ * properties and functions. Alternatively, it can be passed an {@link Element}
+ * subclass as a type argument so elements its page objects produces will be
+ * typed more specifically.
+ *
+ * @param {string} selector the selector relative to the parent node
+ *
+ * @returns {PageObject} a {@link PageObject} instance
+ */
+export default function selector<ElementType extends Element = Element>(
+  selector: string
+): PageObject<ElementType>;
+
+/**
+ * Define a child PageObject. It can optionally be supplied with a
+ * {@link PageObject} subclass definition to allow customizing functionality on
+ * the page object, such as defining (grand)child page objects, or other helpful
+ * properties and functions. Alternatively, it can be passed an {@link Element}
+ * subclass as a type argument so elements its page objects produces will be
+ * typed more specifically.
+ *
+ * @param {string} selector the selector relative to the parent node
+ * @param {Function<PageObject>} [Class] {@link PageObject} subclass that
+ * can be used to extend the functionality of this page object
+ *
+ * @returns {PageObject} a {@link PageObject} subclass instance
+ */
+export default function selector<
+  ElementType extends Element,
+  T extends PageObject<ElementType>
+>(selector: string, Class: PageObjectConstructor<ElementType, T>): T;
+
+/**
+ * Define a child PageObject. It can optionally be supplied with a
+ * {@link PageObject} subclass definition to allow customizing functionality on
+ * the page object, such as defining (grand)child page objects, or other helpful
+ * properties and functions. Alternatively, it can be passed an {@link Element}
+ * subclass as a type argument so elements its page objects produces will be
+ * typed more specifically.
  *
  * @param {string} selector the selector relative to the parent node
  * @param {Function<PageObject>} [Class] optional {@link PageObject} subclass that
@@ -28,6 +65,17 @@ import { validateSelectorArguments } from './-private/helpers';
  * let page = new Page();
  * page.list.elements; // document.body.querySelectorAll('.list')
  * page.list.items.elements; // document.body.querySelectorAll('.list li')
+ *
+ * @example
+ *
+ * import { PageObject, selector } from 'fractal-page-object';
+ *
+ * class Page extends PageObject {
+ *   input = selector<HTMLInputElement>('input');
+ * }
+ * let page = new Page();
+ * page.input.element; // type is HTMLInputElement
+ * page.input.element.value; // no type cast needed
  */
 export default function selector<
   ElementType extends Element = Element,

--- a/packages/fractal-page-object/src/selector.ts
+++ b/packages/fractal-page-object/src/selector.ts
@@ -29,10 +29,10 @@ import { validateSelectorArguments } from './-private/helpers';
  * page.list.elements; // document.body.querySelectorAll('.list')
  * page.list.items.elements; // document.body.querySelectorAll('.list li')
  */
-export default function selector<T extends PageObject>(
-  selector: string,
-  Class?: PageObjectConstructor<T>
-): T {
+export default function selector<
+  ElementType extends Element = Element,
+  T extends PageObject<ElementType> = PageObject<ElementType>
+>(selector: string, Class?: PageObjectConstructor<ElementType, T>): T {
   validateSelectorArguments(selector, Class);
 
   // Return a factory, but typed as the class it will instantiate since the

--- a/packages/fractal-page-object/src/utils.ts
+++ b/packages/fractal-page-object/src/utils.ts
@@ -21,10 +21,10 @@ import type { default as PageObject } from './page-object';
  * @param {string} msg a descriptor for what it could mean when the element doesn't exist
  * @param {PageObject} pageObject the page object
  */
-export function assertExists(
+export function assertExists<ElementType extends Element>(
   msg: string,
-  pageObject: PageObject
-): asserts pageObject is WithElement<PageObject> {
+  pageObject: PageObject<ElementType>
+): asserts pageObject is WithElement<PageObject<ElementType>, ElementType> {
   if (!pageObject.element) {
     throw new Error(
       `${msg} >> Tried selector \`${getDescription(pageObject)}\``
@@ -35,6 +35,8 @@ export function assertExists(
 /**
  * Utility to get the fully resolved selector path of a {@link PageObject}
  */
-export function getDescription(pageObject: PageObject): string {
+export function getDescription<ElementType extends Element>(
+  pageObject: PageObject<ElementType>
+): string {
   return pageObject[DOM_QUERY].selectorArray.toString();
 }


### PR DESCRIPTION
Instrument `PageObject`, `selector`, and `globalSelector` to specify an `Element` sub-type for matched/returned elements. This allows page objects that "know" their matching element type to encode that and remove the need for casting/type-narrowing by consumers of the page object.

Fixes #56