### PR TITLE
Fix type errors in Ember tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ page.form.input.value = ;
 page.form.submit();
 ```
 
+Note that there are no runtime checks enforcing this -- it's just the equivalent of `document.querySelector('.thing') as HTMLButtonElement`.
+
 ### Extending
 
 Page objects can be extended by adding any functionality to the `PageObject` subclass:

--- a/packages/ember-app/tsconfig.json
+++ b/packages/ember-app/tsconfig.json
@@ -13,7 +13,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "noEmitOnError": false,
+    "noEmitOnError": true,
     "noEmit": true,
     "inlineSourceMap": true,
     "inlineSources": true,


### PR DESCRIPTION
#89 introduced some type errors in the Ember tests that I didn't notice because noEmitOnError was set to false. So set it to true and fix up the type errors.

In fixing the type errors, I realized that wrapping `selector()` has gotten a good bit more complex because `selector()`'s type is more complex, so I re-implemented the test to define a generic `wrapSelector()` function that can be used to produce a wrapper that transforms the arguments before passing them to `selector()`. I did the same for `globalSelector()` (whose type is even more complex). We could potentially put these in the library and export them to make them available to consumers, but I want to give them a little more time and get some feedback from the folks (or maybe just one person?) that wraps `selector()` before promoting them to a "public API."