### PR TITLE
Support DocumentFragments & ShadowRoots

### DIFF
--- a/packages/ember-app/tests/integration/page-object-test.ts
+++ b/packages/ember-app/tests/integration/page-object-test.ts
@@ -3,7 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, render, RenderingTestContext } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { globalSelector, PageObject, selector } from 'fractal-page-object';
-import type { PageObjectConstructor } from 'fractal-page-object';
+import {
+  type ElementLike,
+  isElementLike,
+  type PageObjectConstructor,
+} from 'fractal-page-object';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
@@ -65,7 +69,7 @@ module('Integration | page object', function (hooks) {
      */
     function wrapSelector(
       transform: <
-        ElementType extends Element,
+        ElementType extends ElementLike,
         T extends PageObject<ElementType>
       >(
         name: string,
@@ -73,15 +77,15 @@ module('Integration | page object', function (hooks) {
       ) => [string, PageObjectConstructor<ElementType, T>?]
     ) {
       function s<
-        ElementType extends Element = Element
+        ElementType extends ElementLike = Element
       >(name: string): PageObject<ElementType>;
       function s<
-        ElementType extends Element,
+        ElementType extends ElementLike,
         T extends PageObject<ElementType>
       >(name: string, Class: PageObjectConstructor<ElementType, T>): T;
 
       function s<
-        ElementType extends Element = Element,
+        ElementType extends ElementLike = Element,
         T extends PageObject<ElementType> = PageObject<ElementType>
       >(name: string, Class?: PageObjectConstructor<ElementType, T>) {
         [name, Class] = transform(name, Class);
@@ -142,39 +146,39 @@ module('Integration | page object', function (hooks) {
      */
     function wrapGlobalSelector(
       transform: <
-        ElementType extends Element,
+        ElementType extends ElementLike,
         T extends PageObject<ElementType>
       >(
         name: string,
-        rootElement?: Element,
+        rootElement?: ElementLike,
         Class?: PageObjectConstructor<ElementType, T>
-      ) => [string, Element?, PageObjectConstructor<ElementType, T>?]
+      ) => [string, ElementLike?, PageObjectConstructor<ElementType, T>?]
     ) {
       function gs<
-        ElementType extends Element = Element
+        ElementType extends ElementLike = Element
       >(selector: string): PageObject<ElementType>;
       function gs<
-        ElementType extends Element,
+        ElementType extends ElementLike,
         T extends PageObject<ElementType>
       >(name: string, Class: PageObjectConstructor<ElementType, T>): T;
 
       function gs<
-        ElementType extends Element = Element
-      >(selector: string, rootElement: Element): PageObject<ElementType>;
+        ElementType extends ElementLike = Element
+      >(selector: string, rootElement: ElementLike): PageObject<ElementType>;
       function gs<
-        ElementType extends Element,
+        ElementType extends ElementLike,
         T extends PageObject<ElementType>
-      >(name: string, rootElement: Element, Class: PageObjectConstructor<ElementType, T>): T;
+      >(name: string, rootElement: ElementLike, Class: PageObjectConstructor<ElementType, T>): T;
 
       function gs<
-        ElementType extends Element = Element,
+        ElementType extends ElementLike = Element,
         T extends PageObject<ElementType> = PageObject<ElementType>
-      >(...args: [string, PageObjectConstructor<ElementType, T>?] | [string, Element, PageObjectConstructor<ElementType, T>?]) {
+      >(...args: [string, PageObjectConstructor<ElementType, T>?] | [string, ElementLike, PageObjectConstructor<ElementType, T>?]) {
         let name;
         let rootElement;
         let Class;
 
-        if (args[1] instanceof Element) {
+        if (isElementLike(args[1])) {
           [name, rootElement, Class] = transform(args[0], args[1], args[2]);
         } else {
           [name, rootElement, Class] = transform(args[0], undefined, args[1]);
@@ -264,6 +268,48 @@ module('Integration | page object', function (hooks) {
     } finally {
       div.remove();
     }
+  });
+
+  test('it can query the shadow DOM', async function (this: RenderingTestContext, assert) {
+    await render(hbs`<div data-target><div data-child></div></div>`);
+
+    let target = this.element.querySelector('[data-target]')!;
+    let span = document.createElement('span');
+    target?.attachShadow({ mode: 'open' }).append(span);
+
+    let child = this.element.querySelector('[data-child]')!;
+    let childSpan = document.createElement('span');
+    child?.attachShadow({ mode: 'open' }).append(childSpan);
+
+    const ShadowPage = class extends PageObject {
+      span = selector('span');
+    };
+
+    const Page = class extends PageObject {
+      get shadowRoot() {
+        return this.element?.shadowRoot
+          ? new ShadowPage('', this.element.shadowRoot)
+          : new ShadowPage('does_not_exist');
+      }
+
+      get shadowSpan() {
+        return this.element?.shadowRoot
+          ? new PageObject('span', this.element.shadowRoot)
+          : new PageObject('does_not_exist');
+      }
+
+      get childShadowSpan() {
+        let child = this.element?.querySelector('[data-child]')?.shadowRoot;
+        return child
+          ? new PageObject('span', child)
+          : new PageObject('does_not_exist');
+      }
+    };
+    let page = new Page('[data-target]');
+
+    assert.strictEqual(page.shadowRoot.span.element, span);
+    assert.strictEqual(page.shadowSpan.element, span);
+    assert.strictEqual(page.childShadowSpan.element, childSpan);
   });
 
   test('smoke test', async function (assert) {

--- a/packages/fractal-page-object/src/-private/array-stub.ts
+++ b/packages/fractal-page-object/src/-private/array-stub.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 
-import type { WithElement } from './types';
+import type { ElementLike, WithElement } from './types';
 
 /**
  * Base class for {@link PageObject} that contains stub implementations of a
@@ -14,7 +14,7 @@ import type { WithElement } from './types';
  *
  * @private
  */
-export default class ArrayStub<ElementType extends Element> {
+export default class ArrayStub<ElementType extends ElementLike> {
   //
   // Array API
   //

--- a/packages/fractal-page-object/src/-private/clone-with-index.ts
+++ b/packages/fractal-page-object/src/-private/clone-with-index.ts
@@ -1,5 +1,5 @@
 import type PageObject from '../page-object';
-import type { PageObjectConstructor } from './types';
+import type { ElementLike, PageObjectConstructor } from './types';
 
 /**
  * Create a clone of a {@link PageObject}, but with an index specified. If
@@ -13,7 +13,7 @@ import type { PageObjectConstructor } from './types';
  * the matching elements at the given index
  */
 export default function cloneWithIndex<
-  ElementType extends Element,
+  ElementType extends ElementLike,
   T extends PageObject<ElementType>
 >(obj: T, index: number): T {
   let Class = obj.constructor as PageObjectConstructor<

--- a/packages/fractal-page-object/src/-private/create-proxy.ts
+++ b/packages/fractal-page-object/src/-private/create-proxy.ts
@@ -1,6 +1,7 @@
 import PageObjectFactory from './factory';
 import type PageObject from '../page-object';
 import cloneWithIndex from './clone-with-index';
+import { ElementLike } from './types';
 
 /**
  * Create a proxy wrapping a {@link PageObject} and implementing array
@@ -10,7 +11,7 @@ import cloneWithIndex from './clone-with-index';
  *
  * @returns the proxy implementing the page object & array functionality
  */
-export default function createProxy<ElementType extends Element>(
+export default function createProxy<ElementType extends ElementLike>(
   pageObject: PageObject<ElementType>
 ): PageObject<ElementType> {
   return new Proxy(pageObject, {
@@ -71,7 +72,7 @@ export default function createProxy<ElementType extends Element>(
  * {@link PageObject} if the actual property value is a
  * {@link PageObjectFactory}
  */
-function getWithFactorySupport<ElementType extends Element>(
+function getWithFactorySupport<ElementType extends ElementLike>(
   pageObject: PageObject<ElementType>,
   prop: string,
   receiver: unknown

--- a/packages/fractal-page-object/src/-private/factory.ts
+++ b/packages/fractal-page-object/src/-private/factory.ts
@@ -1,5 +1,9 @@
 import PageObject from '../page-object';
-import type { GenericPageObject, PageObjectConstructor } from './types';
+import type {
+  ElementLike,
+  GenericPageObject,
+  PageObjectConstructor,
+} from './types';
 
 /**
  * A factory for creating {@link PageObject}s. The factory is constructed with a
@@ -8,7 +12,7 @@ import type { GenericPageObject, PageObjectConstructor } from './types';
  * the data provided to the factoryt.
  */
 export default class PageObjectFactory<
-  ElementType extends Element,
+  ElementType extends ElementLike,
   T extends PageObject<ElementType>
 > {
   /**
@@ -28,7 +32,7 @@ export default class PageObjectFactory<
    * @param parent the {@link PageObject} to set as the new page object's parent
    * @returns the new page object
    */
-  create(parent?: GenericPageObject | Element): PageObject<ElementType> {
+  create(parent?: GenericPageObject | ElementLike): PageObject<ElementType> {
     let Class =
       this.Class ||
       (PageObject as PageObjectConstructor<

--- a/packages/fractal-page-object/src/-private/global-factory.ts
+++ b/packages/fractal-page-object/src/-private/global-factory.ts
@@ -1,4 +1,4 @@
-import type { PageObjectConstructor } from './types';
+import type { ElementLike, PageObjectConstructor } from './types';
 import PageObject from '../page-object';
 import Factory from './factory';
 
@@ -9,7 +9,7 @@ import Factory from './factory';
  * default to the global root set via {@link setRoot}.
  */
 export default class GlobalPageObjectFactory<
-  ElementType extends Element,
+  ElementType extends ElementLike,
   T extends PageObject<ElementType>
 > extends Factory<ElementType, T> {
   /**
@@ -22,7 +22,7 @@ export default class GlobalPageObjectFactory<
    */
   constructor(
     selector: string,
-    private rootElement?: Element,
+    private rootElement?: ElementLike,
     Class?: PageObjectConstructor<ElementType, T>
   ) {
     super(selector, Class);

--- a/packages/fractal-page-object/src/-private/helpers.ts
+++ b/packages/fractal-page-object/src/-private/helpers.ts
@@ -1,9 +1,9 @@
 import PageObject from '../page-object';
 import safeSelector from './safe-selector';
-import type { PageObjectConstructor } from './types';
+import type { ElementLike, PageObjectConstructor } from './types';
 
 function isPageObjectSubclass<
-  ElementType extends Element,
+  ElementType extends ElementLike,
   T extends PageObject<ElementType>
 >(Class: PageObjectConstructor<ElementType, T>) {
   return (
@@ -12,7 +12,7 @@ function isPageObjectSubclass<
 }
 
 export function validateSelectorArguments<
-  ElementType extends Element,
+  ElementType extends ElementLike,
   T extends PageObject<ElementType>
 >(selector: string, Class?: PageObjectConstructor<ElementType, T>): void {
   if (!selector.trim()) {

--- a/packages/fractal-page-object/src/-private/page-object-state.ts
+++ b/packages/fractal-page-object/src/-private/page-object-state.ts
@@ -1,6 +1,10 @@
 import DOMQuery from './dom-query';
 import { getRoot } from './root';
-import type { GenericPageObject } from './types';
+import {
+  isElementLike,
+  type ElementLike,
+  type GenericPageObject,
+} from './types';
 
 /**
  * This interface describes the internal/private state of a {@link PageObject}.
@@ -10,7 +14,7 @@ import type { GenericPageObject } from './types';
  */
 interface IPageObjectState {
   selector: string;
-  parent: GenericPageObject | Element | null;
+  parent: GenericPageObject | ElementLike | null;
   index: number | null;
 }
 
@@ -42,7 +46,7 @@ export function getDOMQuery(pageObject: GenericPageObject): DOMQuery {
   let { parent, selector, index } = state;
 
   let parentQuery;
-  if (parent instanceof Element) {
+  if (isElementLike(parent)) {
     parentQuery = new DOMQuery(parent);
   } else if (parent) {
     parentQuery = getDOMQuery(parent);

--- a/packages/fractal-page-object/src/-private/root.ts
+++ b/packages/fractal-page-object/src/-private/root.ts
@@ -1,4 +1,6 @@
-let root: Element | undefined;
+import { isElementLike, type ElementLike } from './types';
+
+let root: ElementLike | undefined;
 
 function getEmberTestRoot() {
   // Ideally we would detect if we are running in Ember and if so use
@@ -18,10 +20,10 @@ function getEmberTestRoot() {
  * only match elements that are descendants of this element. The default root
  * element is `document.body`.
  *
- * @param {Element|Function} element the root element or a function that will
- * return it
+ * @param {ElementLike|Function} element the root element or a function that
+ * will return it
  */
-export function setRoot(element: Element): void {
+export function setRoot(element: ElementLike): void {
   root = element;
 }
 
@@ -32,8 +34,8 @@ export function setRoot(element: Element): void {
  *
  * @private
  */
-export function getRoot(): Element {
-  if (root instanceof Element) {
+export function getRoot(): ElementLike {
+  if (isElementLike(root)) {
     return root;
   } else {
     return getEmberTestRoot() || document.body;

--- a/packages/fractal-page-object/src/-private/types.ts
+++ b/packages/fractal-page-object/src/-private/types.ts
@@ -1,6 +1,20 @@
 import type PageObject from '../page-object';
 
 /**
+ * Something that can be wrapped in a {@link PageObject} -- typically an
+ * {@link Element}, but can also be a {@link DocumentFragment} or
+ * {@link ShadowRoot}
+ */
+export type ElementLike = Element | DocumentFragment;
+
+/**
+ * Determines if an object is an {@link ElementType}
+ */
+export function isElementLike(obj: unknown): obj is ElementLike {
+  return obj instanceof Element || obj instanceof DocumentFragment;
+}
+
+/**
  * A generic page object, used in places where we don't care about the page
  * object's `ElementType`
  */
@@ -10,7 +24,7 @@ export type GenericPageObject = PageObject<any>; // eslint-disable-line @typescr
  * A constructor for a {@link PageObject} or {@link PageObject} subclass
  */
 export type PageObjectConstructor<
-  ElementType extends Element,
+  ElementType extends ElementLike,
   T extends PageObject<ElementType>
 > = new (...args: ConstructorParameters<typeof PageObject<ElementType>>) => T;
 
@@ -19,6 +33,6 @@ export type PageObjectConstructor<
  *
  * @see {@link ArrayStub#map} etc.
  */
-export type WithElement<T, ElementType extends Element = Element> = T & {
+export type WithElement<T, ElementType extends ElementLike = Element> = T & {
   element: ElementType;
 };

--- a/packages/fractal-page-object/src/__tests__/dom-query.ts
+++ b/packages/fractal-page-object/src/__tests__/dom-query.ts
@@ -578,4 +578,26 @@ describe('DOMQuery', () => {
     expect(child.query()).toEqual(null);
     expect(child.queryAll()).toEqual([]);
   });
+
+  test('it works with a shadow root', () => {
+    let shadowSpan1 = document.createElement('span');
+    shadowSpan1.id = 'shadowSpan1';
+
+    let shadowSpan2 = document.createElement('span');
+    shadowSpan2.id = 'shadowSpan2';
+
+    span1.attachShadow({ mode: 'open' }).append(shadowSpan1, shadowSpan2);
+
+    let shadowQuery = new DOMQuery(span1.shadowRoot);
+    expect(shadowQuery.query()).toEqual(span1.shadowRoot);
+    expect(shadowQuery.queryAll()).toEqual([span1.shadowRoot]);
+
+    let child = shadowQuery.createChild('span', null);
+    expect(child.query()).toEqual(shadowSpan1);
+    expect(child.queryAll()).toEqual([shadowSpan1, shadowSpan2]);
+
+    child = shadowQuery.createChild('span', 1);
+    expect(child.query()).toEqual(shadowSpan2);
+    expect(child.queryAll()).toEqual([shadowSpan2]);
+  });
 });

--- a/packages/fractal-page-object/src/__tests__/page-object.ts
+++ b/packages/fractal-page-object/src/__tests__/page-object.ts
@@ -525,6 +525,29 @@ describe('PageObject', () => {
     });
   });
 
+  describe('document fragments', () => {
+    test('it works with a document fragment root', () => {
+      let fragment = document.createDocumentFragment();
+      let span = document.createElement('span');
+      fragment.append(span);
+
+      setRoot(fragment);
+
+      let page = new PageObject();
+      expect(getDOMQuery(page).root).toEqual(fragment);
+      expect(getDOMQuery(page).createChild('span', null).query()).toEqual(span);
+    });
+
+    test('it can have a document fragment parent', () => {
+      let fragment = document.createDocumentFragment();
+      let span = document.createElement('span');
+      fragment.append(span);
+
+      let page = new PageObject('span', fragment);
+      expect(getDOMQuery(page).query()).toEqual(span);
+    });
+  });
+
   describe('subclasses', () => {
     let div1: Element;
     let div2: Element;

--- a/packages/fractal-page-object/src/__tests__/types.ts
+++ b/packages/fractal-page-object/src/__tests__/types.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from '@jest/globals';
+import { ElementLike, isElementLike } from '../index';
+
+describe('types', () => {
+  describe('isElementLike', () => {
+    test('works', () => {
+      expect(isElementLike({})).toEqual(false);
+      expect(isElementLike(null)).toEqual(false);
+      expect(isElementLike(document)).toEqual(false);
+      expect(isElementLike(document.createDocumentFragment())).toEqual(true);
+      expect(isElementLike(document.createElement('div'))).toEqual(true);
+    });
+
+    test('type narrows', () => {
+      const doThing = (el: ElementLike) => el;
+      let obj: unknown = document.createElement('div');
+
+      doThing(
+        // @ts-expect-error should produce error
+        obj
+      );
+
+      if (isElementLike(obj)) {
+        doThing(obj);
+      }
+      expect(true).toEqual(true);
+    });
+  });
+});

--- a/packages/fractal-page-object/src/global-selector.ts
+++ b/packages/fractal-page-object/src/global-selector.ts
@@ -1,6 +1,10 @@
 import GlobalPageObjectFactory from './-private/global-factory';
 import PageObject from './page-object';
-import type { PageObjectConstructor } from './-private/types';
+import {
+  isElementLike,
+  type ElementLike,
+  type PageObjectConstructor,
+} from './-private/types';
 import { validateSelectorArguments } from './-private/helpers';
 
 /**
@@ -23,9 +27,9 @@ import { validateSelectorArguments } from './-private/helpers';
  *
  * @returns {PageObject} a {@link PageObject} instance
  */
-export default function globalSelector<ElementType extends Element = Element>(
-  selector: string
-): PageObject<ElementType>;
+export default function globalSelector<
+  ElementType extends ElementLike = Element
+>(selector: string): PageObject<ElementType>;
 
 /**
  * Define a {@link PageObject} with a global scope, i.e. not scoped by its
@@ -50,7 +54,7 @@ export default function globalSelector<ElementType extends Element = Element>(
  * @returns {PageObject} a {@link PageObject} subclass instance
  */
 export default function globalSelector<
-  ElementType extends Element,
+  ElementType extends ElementLike,
   T extends PageObject<ElementType>
 >(selector: string, Class: PageObjectConstructor<ElementType, T>): T;
 
@@ -71,15 +75,14 @@ export default function globalSelector<
  * generates.
  *
  * @param {string} selector the selector
- * @param {Element} rootElement the root element under which to query the
+ * @param {ElementLike} rootElement the root element under which to query the
  * selector.
  *
  * @returns {PageObject} a {@link PageObject} instance
  */
-export default function globalSelector<ElementType extends Element = Element>(
-  selector: string,
-  rootElement: Element
-): PageObject<ElementType>;
+export default function globalSelector<
+  ElementType extends ElementLike = Element
+>(selector: string, rootElement: ElementLike): PageObject<ElementType>;
 
 /**
  * Define a {@link PageObject} with a global scope, i.e. not scoped by its
@@ -98,19 +101,19 @@ export default function globalSelector<ElementType extends Element = Element>(
  * generates.
  *
  * @param {string} selector the selector
- * @param {Element} rootElement the root element under which to query the
+ * @param {ElementLike} rootElement the root element under which to query the
  * selector.
- * @param {Function<PageObject>} [Class] {@link PageObject} subclass that
- * can be used to extend the functionality of this page object
+ * @param {Function<PageObject>} [Class] {@link PageObject} subclass that can be
+ * used to extend the functionality of this page object
  *
  * @returns {PageObject} a {@link PageObject} subclass instance
  */
 export default function globalSelector<
-  ElementType extends Element,
+  ElementType extends ElementLike,
   T extends PageObject<ElementType>
 >(
   selector: string,
-  rootElement: Element,
+  rootElement: ElementLike,
   Class: PageObjectConstructor<ElementType, T>
 ): T;
 
@@ -131,7 +134,7 @@ export default function globalSelector<
  * generates.
  *
  * @param {string} selector the selector
- * @param {Element} rootElement optional the root element under which to query
+ * @param {ElementLike} rootElement optional the root element under which to query
  * the selector.
  * @param {Function<PageObject>} Class optional {@link PageObject} subclass that
  * can be used to extend the functionality of this page object
@@ -189,18 +192,18 @@ export default function globalSelector<
  * page.input.element.value; // no type cast needed
  */
 export default function globalSelector<
-  ElementType extends Element = Element,
+  ElementType extends ElementLike = Element,
   T extends PageObject<ElementType> = PageObject<ElementType>
 >(
   ...args:
     | [string, PageObjectConstructor<ElementType, T>?]
-    | [string, Element, PageObjectConstructor<ElementType, T>?]
+    | [string, ElementLike, PageObjectConstructor<ElementType, T>?]
 ): T {
   let selector = args[0];
   let rootElement;
   let Class;
 
-  if (args[1] instanceof Element) {
+  if (isElementLike(args[1])) {
     rootElement = args[1];
     Class = args[2];
   } else {

--- a/packages/fractal-page-object/src/index.ts
+++ b/packages/fractal-page-object/src/index.ts
@@ -1,5 +1,10 @@
 export { setRoot } from './-private/root';
-export type { PageObjectConstructor, WithElement } from './-private/types';
+export {
+  type ElementLike,
+  isElementLike,
+  type PageObjectConstructor,
+  type WithElement,
+} from './-private/types';
 
 export { default as PageObject } from './page-object';
 

--- a/packages/fractal-page-object/src/page-object.ts
+++ b/packages/fractal-page-object/src/page-object.ts
@@ -1,14 +1,15 @@
 import ArrayStub from './-private/array-stub';
 import createProxy from './-private/create-proxy';
 import { getDOMQuery, setPageObjectState } from './-private/page-object-state';
-import type { GenericPageObject } from './-private/types';
+import type { ElementLike, GenericPageObject } from './-private/types';
 
 /**
  * This class implements all the basic page object functionality, and all page
  * objects must inherit from it. It can host {@link selector} and
  * {@link globalSelector} fields, and will properly instantiate them as nested
  * {@link PageObject}s when accessed. Each page object represents a DOM query
- * that matches zero or more {@link Element}s (or subclasses of {@link Element}
+ * that matches zero or more {@link ElementLike}s (or subclasses of
+ * {@link Element}
  * -- see {@link ElementType}).
  *
  * {@link PageObject}s exist in a tree where each {@link PageObject}'s elements
@@ -86,7 +87,7 @@ import type { GenericPageObject } from './-private/types';
  * new Page('.container', document.body, 1).list.elements;
  */
 export default class PageObject<
-  ElementType extends Element = Element
+  ElementType extends ElementLike = Element
 > extends ArrayStub<ElementType> {
   /**
    * This page object's single matching DOM element -- the first DOM element
@@ -139,13 +140,13 @@ export default class PageObject<
    */
   constructor(
     selector: string,
-    parent?: GenericPageObject | Element | null,
+    parent?: GenericPageObject | ElementLike | null,
     index?: number | null
   );
 
   constructor(
     selector = '',
-    parent: GenericPageObject | Element | null = null,
+    parent: GenericPageObject | ElementLike | null = null,
     index: number | null = null
   ) {
     super();

--- a/packages/fractal-page-object/src/selector.ts
+++ b/packages/fractal-page-object/src/selector.ts
@@ -1,6 +1,6 @@
 import PageObjectFactory from './-private/factory';
 import PageObject from './page-object';
-import type { PageObjectConstructor } from './-private/types';
+import type { ElementLike, PageObjectConstructor } from './-private/types';
 import { validateSelectorArguments } from './-private/helpers';
 
 /**
@@ -15,7 +15,7 @@ import { validateSelectorArguments } from './-private/helpers';
  *
  * @returns {PageObject} a {@link PageObject} instance
  */
-export default function selector<ElementType extends Element = Element>(
+export default function selector<ElementType extends ElementLike = Element>(
   selector: string
 ): PageObject<ElementType>;
 
@@ -34,7 +34,7 @@ export default function selector<ElementType extends Element = Element>(
  * @returns {PageObject} a {@link PageObject} subclass instance
  */
 export default function selector<
-  ElementType extends Element,
+  ElementType extends ElementLike,
   T extends PageObject<ElementType>
 >(selector: string, Class: PageObjectConstructor<ElementType, T>): T;
 
@@ -78,7 +78,7 @@ export default function selector<
  * page.input.element.value; // no type cast needed
  */
 export default function selector<
-  ElementType extends Element = Element,
+  ElementType extends ElementLike = Element,
   T extends PageObject<ElementType> = PageObject<ElementType>
 >(selector: string, Class?: PageObjectConstructor<ElementType, T>): T {
   validateSelectorArguments(selector, Class);

--- a/packages/fractal-page-object/src/utils.ts
+++ b/packages/fractal-page-object/src/utils.ts
@@ -1,5 +1,5 @@
 import { getDOMQuery } from './-private/page-object-state';
-import { WithElement } from './-private/types';
+import { ElementLike, WithElement } from './-private/types';
 
 import type { default as PageObject } from './page-object';
 
@@ -23,7 +23,7 @@ import type { default as PageObject } from './page-object';
  * @param {PageObject} pageObject the page object
  */
 export function assertExists<
-  ElementType extends Element,
+  ElementType extends ElementLike,
   T extends PageObject<ElementType>
 >(
   msg: string,
@@ -40,7 +40,7 @@ export function assertExists<
  * Utility to get the fully resolved selector path of a {@link PageObject}
  */
 export function getDescription<
-  ElementType extends Element,
+  ElementType extends ElementLike,
   T extends PageObject<ElementType>
 >(pageObject: T): string {
   return getDOMQuery(pageObject).selectorArray.toString();


### PR DESCRIPTION
Extend our notion of what a PageObject can wrap & query from only an `Element` to an `Element | DocumentFragment`. Since a `ShadowRoot` is a `DocumentFragment`, this gives us low-level support for querying the shadow DOM.

As [the unit tests](https://github.com/bendemboski/fractal-page-object/compare/shadow-dom?expand=1#diff-9ef83699c0fef2a5fdcd8fb4c2ebded00c5a741d2cf2bf63cf3e27743b60a1cfR273-R313) demonstrate, this allows querying against shadow DOMs, although it is somewhat awkward. But this should unblock experimentation with the shadow DOM, and then perhaps once we have more use cases and usage data, we can implement a more ergonomic solution on top of this, e.g. one of the suggestions in #109.