### PR TITLE
Better shadow DOM implementation

### DIFF
--- a/packages/ember-app/tests/integration/page-object-test.ts
+++ b/packages/ember-app/tests/integration/page-object-test.ts
@@ -69,23 +69,23 @@ module('Integration | page object', function (hooks) {
      */
     function wrapSelector(
       transform: <
-        ElementType extends ElementLike,
+        ElementType extends Element,
         T extends PageObject<ElementType>,
       >(
         name: string,
         Class?: PageObjectConstructor<ElementType, T>,
       ) => [string, PageObjectConstructor<ElementType, T>?],
     ) {
-      function s<ElementType extends ElementLike = Element>(
+      function s<ElementType extends Element = Element>(
         name: string,
       ): PageObject<ElementType>;
       function s<
-        ElementType extends ElementLike,
+        ElementType extends Element,
         T extends PageObject<ElementType>,
       >(name: string, Class: PageObjectConstructor<ElementType, T>): T;
 
       function s<
-        ElementType extends ElementLike = Element,
+        ElementType extends Element = Element,
         T extends PageObject<ElementType> = PageObject<ElementType>,
       >(name: string, Class?: PageObjectConstructor<ElementType, T>) {
         [name, Class] = transform(name, Class);
@@ -146,7 +146,7 @@ module('Integration | page object', function (hooks) {
      */
     function wrapGlobalSelector(
       transform: <
-        ElementType extends ElementLike,
+        ElementType extends Element,
         T extends PageObject<ElementType>,
       >(
         name: string,
@@ -154,20 +154,20 @@ module('Integration | page object', function (hooks) {
         Class?: PageObjectConstructor<ElementType, T>,
       ) => [string, ElementLike?, PageObjectConstructor<ElementType, T>?],
     ) {
-      function gs<ElementType extends ElementLike = Element>(
+      function gs<ElementType extends Element = Element>(
         selector: string,
       ): PageObject<ElementType>;
       function gs<
-        ElementType extends ElementLike,
+        ElementType extends Element,
         T extends PageObject<ElementType>,
       >(name: string, Class: PageObjectConstructor<ElementType, T>): T;
 
-      function gs<ElementType extends ElementLike = Element>(
+      function gs<ElementType extends Element = Element>(
         selector: string,
         rootElement: ElementLike,
       ): PageObject<ElementType>;
       function gs<
-        ElementType extends ElementLike,
+        ElementType extends Element,
         T extends PageObject<ElementType>,
       >(
         name: string,
@@ -176,7 +176,7 @@ module('Integration | page object', function (hooks) {
       ): T;
 
       function gs<
-        ElementType extends ElementLike = Element,
+        ElementType extends Element = Element,
         T extends PageObject<ElementType> = PageObject<ElementType>,
       >(
         ...args:

--- a/packages/fractal-page-object/src/-private/array-stub.ts
+++ b/packages/fractal-page-object/src/-private/array-stub.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 
-import type { ElementLike, WithElement } from './types';
+import type { WithElement } from './types';
 
 /**
  * Base class for {@link PageObject} that contains stub implementations of a
@@ -14,7 +14,7 @@ import type { ElementLike, WithElement } from './types';
  *
  * @private
  */
-export default class ArrayStub<ElementType extends ElementLike> {
+export default class ArrayStub<ElementType extends Element> {
   //
   // Array API
   //

--- a/packages/fractal-page-object/src/-private/clone-with-index.ts
+++ b/packages/fractal-page-object/src/-private/clone-with-index.ts
@@ -1,5 +1,5 @@
 import type PageObject from '../page-object';
-import type { ElementLike, PageObjectConstructor } from './types';
+import type { PageObjectConstructor } from './types';
 
 /**
  * Create a clone of a {@link PageObject}, but with an index specified. If
@@ -13,7 +13,7 @@ import type { ElementLike, PageObjectConstructor } from './types';
  * the matching elements at the given index
  */
 export default function cloneWithIndex<
-  ElementType extends ElementLike,
+  ElementType extends Element,
   T extends PageObject<ElementType>,
 >(obj: T, index: number): T {
   let Class = obj.constructor as PageObjectConstructor<

--- a/packages/fractal-page-object/src/-private/create-proxy.ts
+++ b/packages/fractal-page-object/src/-private/create-proxy.ts
@@ -1,7 +1,6 @@
 import PageObjectFactory from './factory';
 import type PageObject from '../page-object';
 import cloneWithIndex from './clone-with-index';
-import { ElementLike } from './types';
 
 /**
  * Create a proxy wrapping a {@link PageObject} and implementing array
@@ -11,7 +10,7 @@ import { ElementLike } from './types';
  *
  * @returns the proxy implementing the page object & array functionality
  */
-export default function createProxy<ElementType extends ElementLike>(
+export default function createProxy<ElementType extends Element>(
   pageObject: PageObject<ElementType>,
 ): PageObject<ElementType> {
   return new Proxy(pageObject, {
@@ -72,7 +71,7 @@ export default function createProxy<ElementType extends ElementLike>(
  * {@link PageObject} if the actual property value is a
  * {@link PageObjectFactory}
  */
-function getWithFactorySupport<ElementType extends ElementLike>(
+function getWithFactorySupport<ElementType extends Element>(
   pageObject: PageObject<ElementType>,
   prop: string,
   receiver: unknown,

--- a/packages/fractal-page-object/src/-private/factory.ts
+++ b/packages/fractal-page-object/src/-private/factory.ts
@@ -12,7 +12,7 @@ import type {
  * the data provided to the factoryt.
  */
 export default class PageObjectFactory<
-  ElementType extends ElementLike,
+  ElementType extends Element,
   T extends PageObject<ElementType>,
 > {
   /**

--- a/packages/fractal-page-object/src/-private/global-factory.ts
+++ b/packages/fractal-page-object/src/-private/global-factory.ts
@@ -9,7 +9,7 @@ import Factory from './factory';
  * default to the global root set via {@link setRoot}.
  */
 export default class GlobalPageObjectFactory<
-  ElementType extends ElementLike,
+  ElementType extends Element,
   T extends PageObject<ElementType>,
 > extends Factory<ElementType, T> {
   /**

--- a/packages/fractal-page-object/src/-private/helpers.ts
+++ b/packages/fractal-page-object/src/-private/helpers.ts
@@ -1,9 +1,9 @@
 import PageObject from '../page-object';
 import safeSelector from './safe-selector';
-import type { ElementLike, PageObjectConstructor } from './types';
+import type { PageObjectConstructor } from './types';
 
 function isPageObjectSubclass<
-  ElementType extends ElementLike,
+  ElementType extends Element,
   T extends PageObject<ElementType>,
 >(Class: PageObjectConstructor<ElementType, T>) {
   return (
@@ -12,7 +12,7 @@ function isPageObjectSubclass<
 }
 
 export function validateSelectorArguments<
-  ElementType extends ElementLike,
+  ElementType extends Element,
   T extends PageObject<ElementType>,
 >(selector: string, Class?: PageObjectConstructor<ElementType, T>): void {
   if (!selector.trim()) {

--- a/packages/fractal-page-object/src/-private/types.ts
+++ b/packages/fractal-page-object/src/-private/types.ts
@@ -24,15 +24,15 @@ export type GenericPageObject = PageObject<any>; // eslint-disable-line @typescr
  * A constructor for a {@link PageObject} or {@link PageObject} subclass
  */
 export type PageObjectConstructor<
-  ElementType extends ElementLike,
+  ElementType extends Element,
   T extends PageObject<ElementType>,
-> = new (...args: ConstructorParameters<typeof PageObject<ElementType>>) => T;
+> = new (...args: ConstructorParameters<typeof PageObject<Element>>) => T;
 
 /**
  * Helper type for a {@link PageObject}s and subclasses that are known to match an element
  *
  * @see {@link ArrayStub#map} etc.
  */
-export type WithElement<T, ElementType extends ElementLike = Element> = T & {
+export type WithElement<T, ElementType extends Element = Element> = T & {
   element: ElementType;
 };

--- a/packages/fractal-page-object/src/__tests__/dom-query.ts
+++ b/packages/fractal-page-object/src/__tests__/dom-query.ts
@@ -592,8 +592,8 @@ describe('DOMQuery', () => {
     span1.attachShadow({ mode: 'open' }).append(shadowSpan1, shadowSpan2);
 
     let shadowQuery = new DOMQuery(span1.shadowRoot);
-    expect(shadowQuery.query()).toEqual(span1.shadowRoot);
-    expect(shadowQuery.queryAll()).toEqual([span1.shadowRoot]);
+    expect(shadowQuery.query()).toEqual(null);
+    expect(shadowQuery.queryAll()).toEqual([]);
 
     let child = shadowQuery.createChild('span', null);
     expect(child.query()).toEqual(shadowSpan1);

--- a/packages/fractal-page-object/src/global-selector.ts
+++ b/packages/fractal-page-object/src/global-selector.ts
@@ -27,9 +27,9 @@ import { validateSelectorArguments } from './-private/helpers';
  *
  * @returns {PageObject} a {@link PageObject} instance
  */
-export default function globalSelector<
-  ElementType extends ElementLike = Element,
->(selector: string): PageObject<ElementType>;
+export default function globalSelector<ElementType extends Element = Element>(
+  selector: string,
+): PageObject<ElementType>;
 
 /**
  * Define a {@link PageObject} with a global scope, i.e. not scoped by its
@@ -54,7 +54,7 @@ export default function globalSelector<
  * @returns {PageObject} a {@link PageObject} subclass instance
  */
 export default function globalSelector<
-  ElementType extends ElementLike,
+  ElementType extends Element,
   T extends PageObject<ElementType>,
 >(selector: string, Class: PageObjectConstructor<ElementType, T>): T;
 
@@ -80,9 +80,10 @@ export default function globalSelector<
  *
  * @returns {PageObject} a {@link PageObject} instance
  */
-export default function globalSelector<
-  ElementType extends ElementLike = Element,
->(selector: string, rootElement: ElementLike): PageObject<ElementType>;
+export default function globalSelector<ElementType extends Element = Element>(
+  selector: string,
+  rootElement: ElementLike,
+): PageObject<ElementType>;
 
 /**
  * Define a {@link PageObject} with a global scope, i.e. not scoped by its
@@ -109,7 +110,7 @@ export default function globalSelector<
  * @returns {PageObject} a {@link PageObject} subclass instance
  */
 export default function globalSelector<
-  ElementType extends ElementLike,
+  ElementType extends Element,
   T extends PageObject<ElementType>,
 >(
   selector: string,
@@ -192,7 +193,7 @@ export default function globalSelector<
  * page.input.element.value; // no type cast needed
  */
 export default function globalSelector<
-  ElementType extends ElementLike = Element,
+  ElementType extends Element = Element,
   T extends PageObject<ElementType> = PageObject<ElementType>,
 >(
   ...args:

--- a/packages/fractal-page-object/src/page-object.ts
+++ b/packages/fractal-page-object/src/page-object.ts
@@ -8,8 +8,7 @@ import type { ElementLike, GenericPageObject } from './-private/types';
  * objects must inherit from it. It can host {@link selector} and
  * {@link globalSelector} fields, and will properly instantiate them as nested
  * {@link PageObject}s when accessed. Each page object represents a DOM query
- * that matches zero or more {@link ElementLike}s (or subclasses of
- * {@link Element}
+ * that matches zero or more {@link Element}s (or subclasses of {@link Element}
  * -- see {@link ElementType}).
  *
  * {@link PageObject}s exist in a tree where each {@link PageObject}'s elements
@@ -87,7 +86,7 @@ import type { ElementLike, GenericPageObject } from './-private/types';
  * new Page('.container', document.body, 1).list.elements;
  */
 export default class PageObject<
-  ElementType extends ElementLike = Element,
+  ElementType extends Element = Element,
 > extends ArrayStub<ElementType> {
   /**
    * This page object's single matching DOM element -- the first DOM element

--- a/packages/fractal-page-object/src/selector.ts
+++ b/packages/fractal-page-object/src/selector.ts
@@ -1,6 +1,6 @@
 import PageObjectFactory from './-private/factory';
 import PageObject from './page-object';
-import type { ElementLike, PageObjectConstructor } from './-private/types';
+import type { PageObjectConstructor } from './-private/types';
 import { validateSelectorArguments } from './-private/helpers';
 
 /**
@@ -15,7 +15,7 @@ import { validateSelectorArguments } from './-private/helpers';
  *
  * @returns {PageObject} a {@link PageObject} instance
  */
-export default function selector<ElementType extends ElementLike = Element>(
+export default function selector<ElementType extends Element = Element>(
   selector: string,
 ): PageObject<ElementType>;
 
@@ -34,7 +34,7 @@ export default function selector<ElementType extends ElementLike = Element>(
  * @returns {PageObject} a {@link PageObject} subclass instance
  */
 export default function selector<
-  ElementType extends ElementLike,
+  ElementType extends Element,
   T extends PageObject<ElementType>,
 >(selector: string, Class: PageObjectConstructor<ElementType, T>): T;
 
@@ -78,7 +78,7 @@ export default function selector<
  * page.input.element.value; // no type cast needed
  */
 export default function selector<
-  ElementType extends ElementLike = Element,
+  ElementType extends Element = Element,
   T extends PageObject<ElementType> = PageObject<ElementType>,
 >(selector: string, Class?: PageObjectConstructor<ElementType, T>): T {
   validateSelectorArguments(selector, Class);

--- a/packages/fractal-page-object/src/utils.ts
+++ b/packages/fractal-page-object/src/utils.ts
@@ -1,5 +1,5 @@
 import { getDOMQuery } from './-private/page-object-state';
-import { ElementLike, WithElement } from './-private/types';
+import { WithElement } from './-private/types';
 
 import type { default as PageObject } from './page-object';
 
@@ -23,7 +23,7 @@ import type { default as PageObject } from './page-object';
  * @param {PageObject} pageObject the page object
  */
 export function assertExists<
-  ElementType extends ElementLike,
+  ElementType extends Element,
   T extends PageObject<ElementType>,
 >(
   msg: string,
@@ -40,7 +40,7 @@ export function assertExists<
  * Utility to get the fully resolved selector path of a {@link PageObject}
  */
 export function getDescription<
-  ElementType extends ElementLike,
+  ElementType extends Element,
   T extends PageObject<ElementType>,
 >(pageObject: T): string {
   return getDOMQuery(pageObject).selectorArray.toString();


### PR DESCRIPTION
The previous shadow DOM support implementation broke the model a bit. It basically made anything that could be an Element also allowed to be a DocumentFragment. But this wasn't really the intent -- this library is meant to find Elements, not DocumentFragments, and really we just need DocumentFragments to be able to be the _parents_ of PageObjects, not their target.

So adjust the code and types in DOMQuery to capture the fact that DocumentFragments can be query roots, but not query results, and then update all the other types to reflect this as well.